### PR TITLE
LPS-72046 prevent baseModule upgrades from running more than once

### DIFF
--- a/modules/apps/collaboration/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/AnnouncementsWebUpgrade.java
+++ b/modules/apps/collaboration/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/AnnouncementsWebUpgrade.java
@@ -44,8 +44,7 @@ public class AnnouncementsWebUpgrade implements UpgradeStepRegistrator {
 				@Override
 				protected String[] getPortletIds() {
 					return new String[] {
-						"1_WAR_soannouncementsportlet", "83", "84",
-						PortletKeys.ANNOUNCEMENTS
+						"1_WAR_soannouncementsportlet", "83", "84"
 					};
 				}
 

--- a/modules/apps/collaboration/directory/directory-web/src/main/java/com/liferay/directory/web/internal/upgrade/DirectoryWebUpgrade.java
+++ b/modules/apps/collaboration/directory/directory-web/src/main/java/com/liferay/directory/web/internal/upgrade/DirectoryWebUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.directory.web.internal.upgrade;
 
-import com.liferay.directory.web.internal.constants.DirectoryPortletKeys;
 import com.liferay.directory.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
@@ -41,13 +40,7 @@ public class DirectoryWebUpgrade implements UpgradeStepRegistrator {
 
 				@Override
 				protected String[] getPortletIds() {
-					return new String[] {
-						"11", "186", "187", "188",
-						DirectoryPortletKeys.DIRECTORY,
-						DirectoryPortletKeys.FRIENDS_DIRECTORY,
-						DirectoryPortletKeys.MY_SITES_DIRECTORY,
-						DirectoryPortletKeys.SITE_MEMBERS_DIRECTORY
-					};
+					return new String[] {"11", "186", "187", "188"};
 				}
 
 			};

--- a/modules/apps/collaboration/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/upgrade/MicroblogsWebUpgrade.java
+++ b/modules/apps/collaboration/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/upgrade/MicroblogsWebUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.microblogs.web.internal.upgrade;
 
-import com.liferay.microblogs.constants.MicroblogsPortletKeys;
 import com.liferay.microblogs.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
@@ -43,9 +42,7 @@ public class MicroblogsWebUpgrade implements UpgradeStepRegistrator {
 				@Override
 				protected String[] getPortletIds() {
 					return new String[] {
-						"1_WAR_microblogsportlet", "2_WAR_microblogsportlet",
-						MicroblogsPortletKeys.MICROBLOGS,
-						MicroblogsPortletKeys.MICROBLOGS_STATUS_UPDATE
+						"1_WAR_microblogsportlet", "2_WAR_microblogsportlet"
 					};
 				}
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/NotificationsWebUpgrade.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/NotificationsWebUpgrade.java
@@ -47,8 +47,7 @@ public class NotificationsWebUpgrade implements UpgradeStepRegistrator {
 				protected String[] getPortletIds() {
 					return new String[] {
 						"1_WAR_notificationsportlet",
-						"2_WAR_notificationsportlet",
-						NotificationsPortletKeys.NOTIFICATIONS
+						"2_WAR_notificationsportlet"
 					};
 				}
 

--- a/modules/apps/collaboration/recent-documents/recent-documents-web/src/main/java/com/liferay/recent/documents/web/internal/upgrade/RecentDocumentsWebUpgrade.java
+++ b/modules/apps/collaboration/recent-documents/recent-documents-web/src/main/java/com/liferay/recent/documents/web/internal/upgrade/RecentDocumentsWebUpgrade.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
-import com.liferay.recent.documents.web.internal.constants.RecentDocumentsPortletKeys;
 import com.liferay.recent.documents.web.internal.upgrade.v1_0_0.UpgradePortletId;
 
 import org.osgi.service.component.annotations.Component;
@@ -41,9 +40,7 @@ public class RecentDocumentsWebUpgrade implements UpgradeStepRegistrator {
 
 				@Override
 				protected String[] getPortletIds() {
-					return new String[] {
-						"64", RecentDocumentsPortletKeys.RECENT_DOCUMENTS
-					};
+					return new String[] {"64"};
 				}
 
 			};

--- a/modules/apps/foundation/portal/portal-upgrade/bnd.bnd
+++ b/modules/apps/foundation/portal/portal-upgrade/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Upgrade
 Bundle-SymbolicName: com.liferay.portal.upgrade
-Bundle-Version: 2.6.1
+Bundle-Version: 2.7.0
 Export-Package:\
 	com.liferay.portal.upgrade.registry,\
 	com.liferay.portal.upgrade.release

--- a/modules/apps/foundation/portal/portal-upgrade/source-formatter.properties
+++ b/modules/apps/foundation/portal/portal-upgrade/source-formatter.properties
@@ -6,4 +6,5 @@
 ##
 
     upgrade.data.access.connection.excludes=\
+        modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/release/BaseUpgradeServiceModuleRelease.java,\
         modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/release/BaseUpgradeWebModuleRelease.java

--- a/modules/apps/foundation/portal/portal-upgrade/src/main/resources/com/liferay/portal/upgrade/release/packageinfo
+++ b/modules/apps/foundation/portal/portal-upgrade/src/main/resources/com/liferay/portal/upgrade/release/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/social-networking/social-networking-web/src/main/java/com/liferay/social/networking/web/internal/upgrade/SocialNetworkingWebUpgrade.java
+++ b/modules/apps/social-networking/social-networking-web/src/main/java/com/liferay/social/networking/web/internal/upgrade/SocialNetworkingWebUpgrade.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
-import com.liferay.social.networking.constants.SocialNetworkingPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -48,15 +47,7 @@ public class SocialNetworkingWebUpgrade implements UpgradeStepRegistrator {
 						"5_WAR_socialnetworkingportlet",
 						"6_WAR_socialnetworkingportlet",
 						"7_WAR_socialnetworkingportlet",
-						"8_WAR_socialnetworkingportlet",
-						SocialNetworkingPortletKeys.FRIENDS,
-						SocialNetworkingPortletKeys.FRIENDS_ACTIVITIES,
-						SocialNetworkingPortletKeys.MAP,
-						SocialNetworkingPortletKeys.MEMBERS,
-						SocialNetworkingPortletKeys.MEMBERS_ACTIVITIES,
-						SocialNetworkingPortletKeys.MEETUPS,
-						SocialNetworkingPortletKeys.SUMMARY,
-						SocialNetworkingPortletKeys.WALL
+						"8_WAR_socialnetworkingportlet"
 					};
 				}
 

--- a/modules/apps/social-private-messaging/social-private-messaging-web/src/main/java/com/liferay/social/privatemessaging/web/internal/upgrade/PrivateMessagingWebUpgrade.java
+++ b/modules/apps/social-private-messaging/social-private-messaging-web/src/main/java/com/liferay/social/privatemessaging/web/internal/upgrade/PrivateMessagingWebUpgrade.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
-import com.liferay.social.privatemessaging.constants.PrivateMessagingPortletKeys;
 import com.liferay.social.privatemessaging.web.internal.upgrade.v1_0_0.UpgradePortletId;
 
 import org.osgi.service.component.annotations.Component;
@@ -41,10 +40,7 @@ public class PrivateMessagingWebUpgrade implements UpgradeStepRegistrator {
 
 				@Override
 				protected String[] getPortletIds() {
-					return new String[] {
-						"1_WAR_privatemessagingportlet",
-						PrivateMessagingPortletKeys.PRIVATE_MESSAGING
-					};
+					return new String[] {"1_WAR_privatemessagingportlet"};
 				}
 
 			};


### PR DESCRIPTION
Hi @achaparro,

This fix should resolve the issues remaining without running more checks than required. I also tested this fix [LPS-69656](https://issues.liferay.com/browse/LPS-69656) and did not see the announcements upgrade fail.

Let me know if there are any questions or concerns, thanks!