### PR TITLE
[TECHNICAL SUPPORT] LPS-76088 Upgrade fails with com.liferay.document.library.kernel.exception.FileExtensionException when dl.file.extensions is to a non-default value

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
@@ -425,7 +425,8 @@ public class DLServiceVerifyProcess extends VerifyProcess {
 		}
 
 		if (dlFileVersions.isEmpty()) {
-			DLStoreUtil.addFile(companyId, dataRepositoryId, name, new byte[0]);
+			DLStoreUtil.addFile(
+				companyId, dataRepositoryId, name, false, new byte[0]);
 
 			return;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-76088

Hi Alberto,

Can you please review this pull request?

Please take these into consideration when checking my commit:
- dlFileEntry.getName() never contains the extension, because it is just an integer
- that false parameter used in other upgrade classes when adding a DLFileEntry

Can we provide it for the customer as an SDH?
This fix solved the issue, upgrade runs successfully, but let me know if you have any concern. 

Thank you