### PR TITLE
LPS-80193

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -365,6 +365,10 @@ public abstract class BaseDB implements DB {
 			boolean failOnError)
 		throws IOException, NamingException, SQLException {
 
+		if (!template.endsWith(StringPool.SEMICOLON)) {
+			template = template + StringPool.SEMICOLON;
+		}
+
 		template = applyMaxStringIndexLengthLimitation(template);
 
 		if (evaluate) {


### PR DESCRIPTION
Hi, @achaparro. Taking into account this comment by Brian, https://github.com/brianchandotcom/liferay-portal/pull/57773#issuecomment-385306328, I've changed the approach to include a semicolon when evaluating the method runSQLTemplateString. Tell me if you have any questions. Thanks!