### PR TITLE
LPS-86460 update db schema with PID changes

### DIFF
--- a/modules/apps/flags/flags-web/build.gradle
+++ b/modules/apps/flags/flags-web/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	compileOnly project(":apps:flags:flags-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
-	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-lang")
 }

--- a/modules/apps/flags/flags-web/build.gradle
+++ b/modules/apps/flags/flags-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:flags:flags-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":core:petra:petra-lang")
 }

--- a/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/portlet/FlagsPortlet.java
+++ b/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/portlet/FlagsPortlet.java
@@ -49,7 +49,7 @@ import org.osgi.service.component.annotations.Reference;
 public class FlagsPortlet extends MVCPortlet {
 
 	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.flags.web)(release.schema.version=1.0.0))",
+		target = "(&(release.bundle.symbolic.name=com.liferay.flags.web)(release.schema.version=1.0.1))",
 		unbind = "-"
 	)
 	protected void setRelease(Release release) {

--- a/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/portlet/PageFlagsPortlet.java
+++ b/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/portlet/PageFlagsPortlet.java
@@ -50,7 +50,7 @@ import org.osgi.service.component.annotations.Reference;
 public class PageFlagsPortlet extends MVCPortlet {
 
 	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.flags.web)(release.schema.version=1.0.0))",
+		target = "(&(release.bundle.symbolic.name=com.liferay.flags.web)(release.schema.version=1.0.1))",
 		unbind = "-"
 	)
 	protected void setRelease(Release release) {

--- a/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/upgrade/PageFlagsWebUpgrade.java
+++ b/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/upgrade/PageFlagsWebUpgrade.java
@@ -14,11 +14,13 @@
 
 package com.liferay.flags.web.internal.upgrade;
 
+import com.liferay.flags.configuration.FlagsGroupServiceConfiguration;
 import com.liferay.flags.web.internal.upgrade.v1_0_0.UpgradePortletId;
+import com.liferay.portal.configuration.persistence.upgrade.ConfigurationUpgradeStepFactory;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
@@ -29,9 +31,17 @@ public class PageFlagsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register(
+			"0.0.1", "1.0.0", new UpgradePortletId());
 
-		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
-	}
+		registry.register(
+			"1.0.0", "1.0.1",
+			_configurationUpgradeStepFactory.createUpgradeStep(
+				"com.liferay.flags.configuration.FlagsConfiguration",
+				FlagsGroupServiceConfiguration.class.getName()));
+		}
+
+	@Reference
+	private ConfigurationUpgradeStepFactory _configurationUpgradeStepFactory;
 
 }

--- a/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/upgrade/PageFlagsWebUpgrade.java
+++ b/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/upgrade/PageFlagsWebUpgrade.java
@@ -17,8 +17,8 @@ package com.liferay.flags.web.internal.upgrade;
 import com.liferay.flags.configuration.FlagsGroupServiceConfiguration;
 import com.liferay.flags.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.configuration.persistence.upgrade.ConfigurationUpgradeStepFactory;
-import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -31,15 +31,14 @@ public class PageFlagsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register(
-			"0.0.1", "1.0.0", new UpgradePortletId());
+		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
 
 		registry.register(
 			"1.0.0", "1.0.1",
 			_configurationUpgradeStepFactory.createUpgradeStep(
 				"com.liferay.flags.configuration.FlagsConfiguration",
 				FlagsGroupServiceConfiguration.class.getName()));
-		}
+	}
 
 	@Reference
 	private ConfigurationUpgradeStepFactory _configurationUpgradeStepFactory;

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
@@ -48,8 +48,11 @@ public class ConfigurationUpgradeStepFactoryImpl
 		return dbProcessContext -> {
 			try {
 				if (_persistenceManager.exists(oldPid)) {
-					Dictionary<?, ?> dictionary = _persistenceManager.load(
-						oldPid);
+					Dictionary<String, String> dictionary =
+						_persistenceManager.load(oldPid);
+					dictionary.remove("service.pid");
+
+					dictionary.put("service.pid", newPid);
 
 					_persistenceManager.store(newPid, dictionary);
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
@@ -50,6 +50,7 @@ public class ConfigurationUpgradeStepFactoryImpl
 				if (_persistenceManager.exists(oldPid)) {
 					Dictionary<String, String> dictionary =
 						_persistenceManager.load(oldPid);
+
 					dictionary.remove("service.pid");
 
 					dictionary.put("service.pid", newPid);


### PR DESCRIPTION
Since this was found to be reproducible in master, continuing from https://github.com/achaparro/liferay-portal-ee/pull/44#issuecomment-432746952

For RSS, PID was changed in configurationId but not dictionary.
For Flags, neither were changed, so added this to upgrade process

Also updated expected schema version in Flags/PageFlags portlets

cc/ @MichaelPrigge @ChrisKian