### PR TITLE
LPS-91363  | master

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_5/UpgradeContentImages.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_5/UpgradeContentImages.java
@@ -197,12 +197,23 @@ public class UpgradeContentImages extends UpgradeProcess {
 				groupId, folderId, id);
 		}
 		catch (PortalException pe) {
-			_log.error(
+			_log.warn(
 				StringBundler.concat(
 					"Unable to get file entry with group ID ",
 					String.valueOf(groupId), ", folder ID ",
-					String.valueOf(folderId), ", and file name ", id),
-				pe);
+					String.valueOf(folderId), ", and file name ", id,
+					" for resourcePrimKey ", resourcePrimKey)
+				);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Unable to get file entry with group ID ",
+						String.valueOf(groupId), ", folder ID ",
+						String.valueOf(folderId), ", and file name ", id,
+						" for resourcePrimKey ", resourcePrimKey)
+					pe);
+			}
 		}
 
 		return fileEntry;


### PR DESCRIPTION
Hi @achaparro

This PR is about changing log level when an exception is raised because an image/document linked from a journal article is not found.

Reference:
https://issues.liferay.com/browse/LPS-91363

/cc @jcampoy