### PR TITLE
[TECHNICAL-SUPPORT] LPS-92048

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeAsset.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeAsset.java
@@ -16,6 +16,8 @@ package com.liferay.portal.upgrade.v7_0_0;
 
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -53,7 +55,21 @@ public class UpgradeAsset extends UpgradeProcess {
 			sb.append("DLFileVersion) and classPK not in (select fileEntryId ");
 			sb.append("from DLFileEntry)");
 
-			runSQL(sb.toString());
+			DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(sb.toString());
+
+			sb = new StringBundler(5);
+
+			sb.append("delete from AssetEntry where classNameId = ");
+			sb.append(classNameId);
+			sb.append(" and not exists (select null from DLFileVersion where ");
+			sb.append("fileVersionId = classPK) and not exists (select null ");
+			sb.append("from DLFileEntry where fileEntryId = classPK)");
+
+			String sql = sb.toString();
+
+			dbTypeToSQLMap.add(DBType.POSTGRESQL, sql);
+
+			runSQL(dbTypeToSQLMap);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeExpando.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeExpando.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.upgrade.v7_0_5;
 
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 /**
@@ -22,9 +24,23 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 public class UpgradeExpando extends UpgradeProcess {
 
 	protected void deleteOrphanExpandoRow() throws Exception {
-		runSQL(
-			"delete from ExpandoRow where rowId_ not in (select rowId_ from " +
-				"ExpandoValue)");
+		StringBuilder sb = new StringBuilder(2);
+
+		sb.append("delete from ExpandoRow where rowId_ not in (select ");
+		sb.append("rowId_ from ExpandoValue)");
+
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(sb.toString());
+
+		sb = new StringBuilder(2);
+
+		sb.append("delete from ExpandoRow er where not exists (select null ");
+		sb.append("from ExpandoValue ev where ev.rowId_ = er.rowId_)");
+
+		String sql = sb.toString();
+
+		dbTypeToSQLMap.add(DBType.POSTGRESQL, sql);
+
+		runSQL(dbTypeToSQLMap);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeExpando.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeExpando.java
@@ -24,19 +24,15 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 public class UpgradeExpando extends UpgradeProcess {
 
 	protected void deleteOrphanExpandoRow() throws Exception {
-		StringBuilder sb = new StringBuilder(2);
+		String sql =
+			"delete from ExpandoRow where rowId_ not in (select rowId_ from " +
+				"ExpandoValue)";
 
-		sb.append("delete from ExpandoRow where rowId_ not in (select ");
-		sb.append("rowId_ from ExpandoValue)");
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(sql);
 
-		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(sb.toString());
-
-		sb = new StringBuilder(2);
-
-		sb.append("delete from ExpandoRow er where not exists (select null ");
-		sb.append("from ExpandoValue ev where ev.rowId_ = er.rowId_)");
-
-		String sql = sb.toString();
+		sql =
+			"delete from ExpandoRow er where not exists (select null from " +
+				"ExpandoValue ev where ev.rowId_ = er.rowId_)";
 
 		dbTypeToSQLMap.add(DBType.POSTGRESQL, sql);
 


### PR DESCRIPTION
/cc @knchau 

Notes from Kimberly:

> The issue is that database upgrades take a longer time to complete due to the use of the clause NOT IN, since it needs to look for the values twice. This degrades the query performance. NOT EXISTS looks at the missing values once, making this query ore efficient.
> 
> Taking into account Alberto's comment, I have changed the query in the cases that Postrges database is being used.
> 
> The DBTypeToSQLMap is the framework used to apply the newly converted string to Postgres databases. The original query string will be applied when the database is not Postgres.
> 
> LPS-92048