### PR TITLE
[TECHNICAL-SUPPORT] LPS-92509

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
@@ -65,10 +65,10 @@ public class DB2SQLTransformerLogic extends BaseSQLTransformerLogic {
 	protected String replaceDropTableIfExistsText(Matcher matcher) {
 		StringBundler sb = new StringBundler(5);
 
-		sb.append("BEGIN ");
-		sb.append("DECLARE CONTINUE HANDLER FOR SQLSTATE '42704' ");
-		sb.append("BEGIN END; ")
-		sb.append("EXECUTE IMMEDIATE 'DROP TABLE $1'; ");
+		sb.append("BEGIN\n");
+		sb.append("DECLARE CONTINUE HANDLER FOR SQLSTATE '42704'\n");
+		sb.append("BEGIN END;\n");
+		sb.append("EXECUTE IMMEDIATE 'DROP TABLE $1';\n");
 		sb.append("END");
 
 		String dropTableIfExists = sb.toString();

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.internal.dao.sql.transformer.SQLFunctionTransformer;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -58,6 +59,21 @@ public class DB2SQLTransformerLogic extends BaseSQLTransformerLogic {
 	@Override
 	protected String replaceCastText(Matcher matcher) {
 		return matcher.replaceAll("CAST($1 AS VARCHAR(254))");
+	}
+
+	@Override
+	protected String replaceDropTableIfExistsText(Matcher matcher) {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("BEGIN ");
+		sb.append("DECLARE CONTINUE HANDLER FOR SQLSTATE '42704' ");
+		sb.append("BEGIN END; ")
+		sb.append("EXECUTE IMMEDIATE 'DROP TABLE $1'; ");
+		sb.append("END");
+
+		String dropTableIfExists = sb.toString();
+
+		return matcher.replaceAll(dropTableIfExists);
 	}
 
 	private Function<String, String> _getAlterColumnTypeFunction() {

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogicTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogicTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.dao.sql.transformer;
 
 import com.liferay.portal.dao.db.TestDB;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +33,15 @@ public class DB2SQLTransformerLogicTest
 
 	@Override
 	public String getDropTableIfExistsTextTransformedSQL() {
-		return "DROP TABLE IF EXISTS Foo";
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("BEGIN\n");
+		sb.append("DECLARE CONTINUE HANDLER FOR SQLSTATE '42704'\n");
+		sb.append("BEGIN END;\n");
+		sb.append("EXECUTE IMMEDIATE 'DROP TABLE Foo';\n");
+		sb.append("END");
+
+		return sb.toString();
 	}
 
 	@Test


### PR DESCRIPTION
cc/@matthewchan123


Notes from Matthew:
> https://issues.liferay.com/browse/LPS-92509
> 
> This PR address an error in the DB2 upgrade process where tables fail to be dropped. The functionality of the command [DROP_TABLE_IF_EXISTS](https://github.com/liferay/liferay-portal/blob/dfeea96b35f2700cd1d927190c403c490f36cb3c/sql/update-6.2.0-7.0.0.sql#L13-L15) was not added for DB2 database language, and is noticeable when upgrading from 6.2 to 7.0 for tables AssetTagProperty, CyrusUser, and CyrusVirtual, where error -104 is shown and the tables incorrectly remain in database after the upgrade.
> 
> The proposed fix implemented in this PR is to add a method overriding replaceDropTableIfExistsText for DB2SQLTransformerLogic.java adjusted to DB2's specific SQL syntax. This solution takes inspiration from the OracleSQLTransformerLogic.java method [replaceDropTableIfExistsText](https://github.com/liferay/liferay-portal/blob/dfeea96b35f2700cd1d927190c403c490f36cb3c/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java#L69-L85) which also overrides the [default function](https://github.com/liferay/liferay-portal/blob/dfeea96b35f2700cd1d927190c403c490f36cb3c/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java#L222-L224) of same name in BaseSQLTransformerLogic.java class.
> 
> With the inclusion of this change, the three aforementioned tables are successfully removed from DB2 and throw no exceptions should they not have existed beforehand. Future upgrade scripts for this database language that drop tables are affected by the fix as well.
>
> It seems the best implementation is to use this continue handler as it is native DB2 SQL PL. Writing a code block the oracle way requires an extra plugin for DB2 which [isn't enabled by default](https://stackoverflow.com/questions/27982019/an-unexpected-token-exception-was-found-in-pl-sqldb2). Thus, since we can't know for certain whether a client has PL/SQL support, I think we should stick to the exception handler as is.