### PR TITLE
[TS]LPS-93431

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd
@@ -6,6 +6,6 @@ Import-Package:\
 	!org.apache.poi.ss.usermodel.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.1.0
+Liferay-Require-SchemaVersion: 2.1.1
 Liferay-Service: true
 -includeresource: @poi-[0-9]*.jar

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
@@ -75,6 +75,11 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 			"2.0.0", "2.1.0",
 			new com.liferay.dynamic.data.lists.internal.upgrade.v2_1_0.
 				UpgradeSchema());
+
+		registry.register(
+			"2.1.0", "2.1.1",
+			new com.liferay.dynamic.data.lists.internal.upgrade.v2_1_1.
+				UpgradeSchema());
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_1_1/UpgradeSchema.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_1_1/UpgradeSchema.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.internal.upgrade.v2_1_1;
+
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Types;
+
+/**
+ * @author Christopher Kian
+ */
+public class UpgradeSchema extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+			try (ResultSet rs = databaseMetaData.getColumns(
+					dbInspector.getCatalog(), dbInspector.getSchema(),
+					dbInspector.normalizeName("DDLRecordSet"), null)) {
+
+				while (rs.next()) {
+					String columnName = StringUtil.toLowerCase(
+						rs.getString("COLUMN_NAME"));
+
+					if (columnName.equals("versionuserid")) {
+						int dataType = rs.getInt("DATA_TYPE");
+
+						if (dataType == Types.VARCHAR) {
+							String template = StringUtil.read(
+								UpgradeSchema.class.getResourceAsStream(
+									"dependencies/update.sql"));
+
+							runSQLTemplateString(template, false, false);
+						}
+
+						return;
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/com/liferay/dynamic/data/lists/internal/upgrade/v1_0_2/dependencies/update.sql
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/com/liferay/dynamic/data/lists/internal/upgrade/v1_0_2/dependencies/update.sql
@@ -1,6 +1,6 @@
 alter table DDLRecord add recordSetVersion VARCHAR(75) null;
 
-alter table DDLRecordSet add versionUserId VARCHAR(75) null;
+alter table DDLRecordSet add versionUserId LONG null;
 alter table DDLRecordSet add versionUserName VARCHAR(75) null;
 alter table DDLRecordSet add version VARCHAR(75) null;
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/com/liferay/dynamic/data/lists/internal/upgrade/v2_1_1/dependencies/update.sql
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/com/liferay/dynamic/data/lists/internal/upgrade/v2_1_1/dependencies/update.sql
@@ -1,0 +1,1 @@
+alter table DDLRecordSet modify versionUserId LONG;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93431

Resent from https://github.com/achaparro/liferay-portal/pull/293

Hey Alberto,

I've made the changes you asked for on the previous PR (fixed the initial upgrade process and added a check before altering the column).  I've tested the following scenarios on Sybase and confirmed they work as intended:
Upgrade from 6.2 (using revised 1.0.2 upgrade process)
Upgrade from 6.2 (using 2.1.1 upgrade process)
Upgrade from master (column is already upgraded, so nothing happens)

As far as testing on all DB types, I did some research and found nothing explicitly preventing the conversion of VARCHAR to DECIMAL, BIGINT, etc.  The only stipulation is the current data (if any) must be convertible.  If it isn't, some DBs will throw errors while others leave a null value (if the column allows for null).  In either case, the versionUserId value should always be convertible, so there should be no issues.  I can manually double-check on each DB type too if needed.

Let me know if you have any questions, thanks!