### PR TITLE
[TECHNICAL-SUPPORT] LPS-95219

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/LayoutAdminWebUpgrade.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/LayoutAdminWebUpgrade.java
@@ -18,6 +18,7 @@ import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.layout.admin.web.internal.upgrade.v_1_0_0.UpgradeLayout;
 import com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType;
 import com.liferay.layout.admin.web.internal.upgrade.v_1_0_2.UpgradeLayoutSetTypeSettings;
+import com.liferay.layout.admin.web.internal.upgrade.v_1_0_3.UpgradeLayoutTemplateId;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
@@ -48,6 +49,8 @@ public class LayoutAdminWebUpgrade implements UpgradeStepRegistrator {
 			"1.0.1", "1.0.2",
 			new UpgradeLayoutSetTypeSettings(
 				_groupLocalService, _layoutSetLocalService));
+
+		registry.register("1.0.2", "1.0.3", new UpgradeLayoutTemplateId());
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_3/UpgradeLayoutTemplateId.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_3/UpgradeLayoutTemplateId.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.admin.web.internal.upgrade.v_1_0_3;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Sam Ziemer
+ */
+public class UpgradeLayoutTemplateId extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		updateLayoutTemplateId();
+	}
+
+	protected void updateLayoutTemplateId() throws Exception {
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select plid, typeSettings from Layout where typesettings " +
+					"like '%layout-template-id=1_2_1_columns%'");
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBatch(
+				connection.prepareStatement(
+					"update Layout set typeSettings = ? where plid = ?"))) {
+
+			try (ResultSet rs = ps1.executeQuery()) {
+				while (rs.next()) {
+					long plid = rs.getLong("plid");
+
+					String typeSettings = rs.getString("typeSettings");
+
+					typeSettings = StringUtil.replace(
+						typeSettings, "layout-template-id=1_2_1_columns",
+						"layout-template-id=1_2_1_columns_ii");
+
+					ps2.setString(1, typeSettings);
+
+					ps2.setLong(2, plid);
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Between 7.0 and 7.1 we added a few additional layout page templates, one of which was a 1_2_1 50/50 split. This left us with 2 layout-template-ids with 1_2_1_columns so we added _i and _ii to the end of the Ids, however, layouts currently using a 1_2_1 column layout were never updated upon upgrading.