### PR TITLE
LPS-82804

### DIFF
--- a/modules/apps/document-library/document-library-repository-cmis-impl/bnd.bnd
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/bnd.bnd
@@ -27,3 +27,4 @@ Import-Package:\
 	!org.relaxng.datatype.*,\
 	\
 	*
+Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/document-library/document-library-repository-cmis-impl/build.gradle
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly group: "org.codehaus.woodstox", name: "woodstox-core-asl", version: "4.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:document-library:document-library-repository-cmis-api")
+	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/upgrade/DLRepositoryCMISUpgrade.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/upgrade/DLRepositoryCMISUpgrade.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.cmis.internal.upgrade;
+
+import com.liferay.document.library.repository.cmis.internal.upgrade.v1_0_0.UpgradeKernelPackage;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
+public class DLRepositoryCMISUpgrade implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register("0.0.0", "1.0.0", new UpgradeKernelPackage());
+
+		registry.register("0.0.1", "1.0.0", new UpgradeKernelPackage());
+	}
+
+}

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/upgrade/v1_0_0/UpgradeKernelPackage.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/upgrade/v1_0_0/UpgradeKernelPackage.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.cmis.internal.upgrade.v1_0_0;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class UpgradeKernelPackage
+	extends com.liferay.portal.upgrade.v7_0_0.UpgradeKernelPackage {
+
+	@Override
+	protected String[][] getClassNames() {
+		return _CLASS_NAMES;
+	}
+
+	@Override
+	protected String[][] getResourceNames() {
+		return _RESOURCE_NAMES;
+	}
+
+	private static final String[][] _CLASS_NAMES = {
+		{
+			"com.liferay.portal.repository.cmis.",
+			"com.liferay.document.library.repository.cmis.internal."
+		}
+	};
+
+	private static final String[][] _RESOURCE_NAMES = {};
+
+}


### PR DESCRIPTION
Hey @achaparro,

The CMIS classes were moved to a different package, but an upgrade was never
written to fix the ClassName table (this happened in 7.0.x).

Could you take a look at these changes? I'm not 100% sure if this is the best
approach to fix this.

Please *don't* send this to Brian.  I'll send it to QA for further testing when
you confirm it is ok.

Thanks!