### PR TITLE
[TECHNICAL-SUPPORT] LPS-96987

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.internal.upgrade;
 
 import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayoutPermissions;
+import com.liferay.layout.internal.upgrade.v1_0_1.UpgradeLayoutParentPlid;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,6 +29,7 @@ public class LayoutImplUpgrade implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register("0.0.0", "1.0.0", new UpgradeLayoutPermissions());
+		registry.register("1.0.0", "1.0.1", new UpgradeLayoutParentPlid());
 	}
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.upgrade.v1_0_1;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Matthew Chan
+ */
+public class UpgradeLayoutParentPlid extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		String sql = StringBundler.concat(
+			"create table TEMP (select l1.plid as plid, l2.plid as parentPlid ",
+			"from Layout l1 left join Layout l2 on l1.groupId = l2.groupId ",
+			"and l1.privateLayout = l2.privateLayout and l1.parentLayoutId = ",
+			"l2.layoutId)");
+
+		runSQL(sql);
+
+		runSQL("create unique index IX_TEMP on TEMP (plid)");
+
+		runSQL(
+			"update Layout set parentPlid = (select parentPlid from TEMP " +
+				"where Layout.plid = TEMP.plid)");
+
+		runSQL("drop table TEMP");
+
+		runSQL("update Layout set parentPlid = 0 where parentPlid is null");
+	}
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
@@ -25,10 +25,10 @@ public class UpgradeLayoutParentPlid extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		String sql = StringBundler.concat(
-			"create table TEMP (select l1.plid as plid, l2.plid as parentPlid ",
-			"from Layout l1 left join Layout l2 on l1.groupId = l2.groupId ",
-			"and l1.privateLayout = l2.privateLayout and l1.parentLayoutId = ",
-			"l2.layoutId)");
+			"create table TEMP as (select l1.plid as plid, l2.plid as ",
+			"parentPlid from Layout l1 left join Layout l2 on l1.groupId = ",
+			"l2.groupId and l1.privateLayout = l2.privateLayout and ",
+			"l1.parentLayoutId = l2.layoutId)");
 
 		runSQL(sql);
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
@@ -35,12 +35,10 @@ public class UpgradeLayoutParentPlid extends UpgradeProcess {
 		runSQL("create unique index IX_TEMP on TEMP (plid)");
 
 		runSQL(
-			"update Layout set parentPlid = (select parentPlid from TEMP " +
-				"where Layout.plid = TEMP.plid)");
+			"update Layout set parentPlid = (select coalesce(parentPlid, 0) " +
+				"from TEMP where Layout.plid = TEMP.plid)");
 
 		runSQL("drop table TEMP");
-
-		runSQL("update Layout set parentPlid = 0 where parentPlid is null");
 	}
 
 }


### PR DESCRIPTION
/cc @mathewchan123

I am not sure if the usage of the [coalesce](https://github.com/achaparro/liferay-portal/pull/325/commits/2463ca8638f18c2b1cde13315c11fbece6e0a95c#diff-3dbd74e449d2aaf6977ec8df60e51a31R38) function is allowed, but it appears to be supported by all of the databases we support. 

Notes from Matt:

> https://issues.liferay.com/browse/LPS-96987
> 
> Issue:
> After upgrading to 7.2, the dropdown menu of child pages no longer shows when hovering a page in Site Navigation portlet.
> 
> Cause:
> ParentPlid is a column introduced to layouts in liferay 7.2, and logic has not yet been implemented to populate parentPlids of old layouts. Pages created after the upgrade have this column filled properly.
> 
> Fix:
> We can write a class that extends UpgradeProcess in Layout which gets the parent layout's plid in a SQL query and then updates the Layout table. After deploying this change, liferay should upgrade the osgi bundle, which fills the table for affected entities and correctly shows the hierarchy in the user interface.