### PR TITLE
LPS-106297 Disabled text field validation is enabled

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
@@ -392,6 +392,13 @@ public class DDMFormEvaluatorHelper {
 		return false;
 	}
 
+	protected boolean isFieldReadOnly(
+		DDMFormEvaluatorFieldContextKey ddmFormEvaluatorFieldContextKey) {
+
+		return getBooleanPropertyValue(
+			ddmFormEvaluatorFieldContextKey, "readOnly", false);
+	}
+
 	protected boolean isFieldVisible(
 		DDMFormEvaluatorFieldContextKey ddmFormFieldContextKey) {
 
@@ -452,6 +459,10 @@ public class DDMFormEvaluatorHelper {
 			entry.getKey();
 
 		if (isFieldEmpty(ddmFormEvaluatorFieldContextKey)) {
+			return;
+		}
+
+		if (isFieldReadOnly(ddmFormEvaluatorFieldContextKey)) {
 			return;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-106297

**Issue:**
Text field validation for disabled fields is validated and results in a form that cannot be submitted.

**Solution:**
These changes pertain to disabled fields. Form submission will not be prevented from a field validation error if the field is disabled/`readOnly`. 

Before validating the field, it checks if the field is a `readOnly` field. If it is, then that means the field is disabled and would not need to be validated. Otherwise, if the field is not a `readOnly` field, it would be validated per usual.