### PR TITLE
LPS-106402 - My Organizations portlet should also check for Organization level permissions

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyOrganizationsPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyOrganizationsPortlet.java
@@ -16,9 +16,9 @@ package com.liferay.users.admin.web.internal.portlet;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -74,17 +74,28 @@ public class MyOrganizationsPortlet extends UsersAdminPortlet {
 					renderRequest, "organizationId");
 
 				if (organizationId == 0) {
-					PortalPermissionUtil.check(
-						PermissionThreadLocal.getPermissionChecker(),
-						ActionKeys.ADD_ORGANIZATION);
+					long parentOrganizationId = ParamUtil.getLong(
+						renderRequest,
+						"parentOrganizationSearchContainerPrimaryKeys");
+
+					if (parentOrganizationId == 0) {
+						PortalPermissionUtil.check(
+							PermissionThreadLocal.getPermissionChecker(),
+							ActionKeys.ADD_ORGANIZATION);
+					}
+					else {
+						OrganizationPermissionUtil.contains(
+							PermissionThreadLocal.getPermissionChecker(),
+							parentOrganizationId, ActionKeys.ADD_ORGANIZATION);
+					}
 				}
 			}
-			catch (PrincipalException pe) {
+			catch (Exception e) {
 				if (_log.isDebugEnabled()) {
-					_log.debug(pe, pe);
+					_log.debug(e, e);
 				}
 
-				SessionErrors.add(renderRequest, pe.getClass());
+				SessionErrors.add(renderRequest, e.getClass());
 
 				path = "/error.jsp";
 			}


### PR DESCRIPTION
Hi @achaparro!

https://issues.liferay.com/browse/LPP-35975
https://issues.liferay.com/browse/LPS-106402

The reproduction steps for this issue are a bit complicated, but ultimately this issue boils down to the fact that, when using the My Organizations portlet, the add organization permission is only checked on the portal level. Specifically, it checks for the permission labeled "Portal: Add Organization" in the UI. Therefore, if the permission is added on an organizational basis such as in an organization role, the check fails and the request is denied. This is inconsistent with how the check operates in the Users and Organizations portlet and thus can lead to user confusion.

The fix therefore adds a secondary check to see if a parentOrganizationId was sent as a parameter. If so, it'll check if the user has permission to add through the OrganizationPermissionUtil. This check is similar to one made in the addOrganization function in OrganizationServiceImpl.

Please let me know if you have any questions or if I can clarify anything further. Thanks!