### PR TITLE
LPS-96981 DBInspectorTest#testHasColumnTypeDate fails on Sybase

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SybaseDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SybaseDB.java
@@ -176,9 +176,11 @@ public class SybaseDB extends BaseDB {
 
 	protected static final String DROP_COLUMN = "drop column";
 
+	private static final int _SQL_TYPE_TIMESTAMP = 11;
+
 	private static final int[] _SQL_TYPES = {
 		Types.LONGVARBINARY, Types.LONGVARBINARY, Types.INTEGER,
-		Types.TIMESTAMP, Types.DOUBLE, Types.INTEGER, Types.DECIMAL,
+		_SQL_TYPE_TIMESTAMP, Types.DOUBLE, Types.INTEGER, Types.DECIMAL,
 		Types.VARCHAR, Types.LONGVARCHAR, Types.VARCHAR
 	};
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-96981

**DBInspectorTest#testHasColumnTypeDate** fails on Sybase because here  [DBInspector.java#L125](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java#L125) Sybase returns 11 in TIMESTAMP columns, instead of 93 (`java.sql.Types.TIMESTAMP` value).

More information see: http://infocenter.sybase.com/help/topic/com.sybase.infocenter.dc38454.1570/doc/html/har1340078811386.html

In order to solve this, I am changing TIMESTAMP column value in `_SQL_TYPES` variable to 11.
