### PR TITLE
LPS-105613 Use VerifyGroup only once after upgrading.

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -43,6 +43,7 @@ import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.util.InitUtil;
 import com.liferay.portal.util.PortalClassPathUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.VerifyGroup;
 import com.liferay.portal.verify.VerifyProperties;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -114,6 +115,10 @@ public class DBUpgrader {
 			upgrade();
 
 			_checkClassNamesAndResourceActions();
+
+			VerifyGroup verifyGroup = new VerifyGroup();
+
+			verifyGroup.verify();
 
 			verify();
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -23,8 +23,6 @@ public class VerifyProcessSuite extends VerifyProcess {
 
 	@Override
 	protected void doVerify() throws Exception {
-		verify(new VerifyGroup());
-
 		verify(new VerifyResourcePermissions());
 	}
 


### PR DESCRIPTION
Hello @achaparro,

As we discussed, we can move verifyGroup to the upgrade process, similar to how we have verifyProperties. Since verifyGroup relies so heavily on service calls, this should be a better solution until we can remove it after support for 7.0 has stopped.