### PR TITLE
LPS-108805 | Upgrade portlet preferences related to fragment entry links from 7.1.x

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
+import com.liferay.portal.kernel.view.count.ViewCountManager;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.step.util.UpgradeStepFactory;
 
@@ -107,5 +108,8 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Reference
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Reference
+	private ViewCountManager _viewCountManager;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
@@ -14,6 +14,7 @@
 
 package com.liferay.fragment.internal.upgrade;
 
+import com.liferay.fragment.internal.upgrade.v1_1_0.UpgradePortletPreferences;
 import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentCollectionTable;
 import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryLinkTable;
 import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryTable;
@@ -48,8 +49,10 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register("1.0.1", "1.0.2", new DummyUpgradeStep());
 
+		registry.register("1.0.2", "1.1.0", new UpgradePortletPreferences());
+
 		registry.register(
-			"1.0.2", "2.0.0",
+			"1.1.0", "2.0.0",
 			new BaseUpgradeSQLServerDatetime(
 				new Class<?>[] {
 					FragmentCollectionTable.class, FragmentEntryLinkTable.class,

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
@@ -21,6 +21,7 @@ import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryTable;
 import com.liferay.fragment.internal.upgrade.v2_1_0.UpgradeSchema;
 import com.liferay.fragment.internal.upgrade.v2_2_1.UpgradeFragmentEntry;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
@@ -53,7 +54,8 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"1.0.2", "1.1.0",
-			new UpgradePortletPreferences(_layoutLocalService));
+			new UpgradePortletPreferences(
+				_layoutLocalService, _portletPreferencesLocalService));
 
 		registry.register(
 			"1.1.0", "2.0.0",
@@ -102,5 +104,8 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
@@ -20,6 +20,7 @@ import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryLinkTable;
 import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryTable;
 import com.liferay.fragment.internal.upgrade.v2_1_0.UpgradeSchema;
 import com.liferay.fragment.internal.upgrade.v2_2_1.UpgradeFragmentEntry;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
@@ -27,6 +28,7 @@ import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.step.util.UpgradeStepFactory;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author José Ángel Jiménez
@@ -49,7 +51,9 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register("1.0.1", "1.0.2", new DummyUpgradeStep());
 
-		registry.register("1.0.2", "1.1.0", new UpgradePortletPreferences());
+		registry.register(
+			"1.0.2", "1.1.0",
+			new UpgradePortletPreferences(_layoutLocalService));
 
 		registry.register(
 			"1.1.0", "2.0.0",
@@ -95,5 +99,8 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 				UpgradeFragmentEntry(),
 			new com.liferay.fragment.internal.upgrade.v2_3_0.UpgradeSchema());
 	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/FragmentServiceUpgrade.java
@@ -21,7 +21,6 @@ import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryTable;
 import com.liferay.fragment.internal.upgrade.v2_1_0.UpgradeSchema;
 import com.liferay.fragment.internal.upgrade.v2_2_1.UpgradeFragmentEntry;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
@@ -55,8 +54,7 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"1.0.2", "1.1.0",
-			new UpgradePortletPreferences(
-				_layoutLocalService, _portletPreferencesLocalService));
+			new UpgradePortletPreferences(_layoutLocalService));
 
 		registry.register(
 			"1.1.0", "2.0.0",
@@ -105,9 +103,6 @@ public class FragmentServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
-
-	@Reference
-	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private ViewCountManager _viewCountManager;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -71,7 +71,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 	protected void upgradePortletPreferences() throws Exception {
 		try (PreparedStatement ps = connection.prepareStatement(
 				"select classPK, companyId, groupId, namespace from " +
-					"FragmentEntryLink;");
+					"FragmentEntryLink");
 			ResultSet rs = ps.executeQuery()) {
 
 			while (rs.next()) {
@@ -102,7 +102,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		sb.append("join Group_ on Layout.groupId = Group_.groupId where ");
 		sb.append("Layout.type_ = '");
 		sb.append(LayoutConstants.TYPE_CONTROL_PANEL);
-		sb.append("';");
+		sb.append("'");
 
 		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
 			ResultSet rs = ps.executeQuery()) {
@@ -150,7 +150,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		sb.append(groupId);
 		sb.append(" or PortletPreferences.plid = ");
 		sb.append(companyControlPanelPlid);
-		sb.append(");");
+		sb.append(")");
 
 		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
 			ResultSet rs = ps.executeQuery()) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.internal.upgrade.v1_1_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Ricardo Couso
+ */
+public class UpgradePortletPreferences extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+
+	}
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -15,6 +15,7 @@
 package com.liferay.fragment.internal.upgrade.v1_1_0;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -45,6 +46,14 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		_portletPreferencesLocalService = portletPreferencesLocalService;
 	}
 
+	protected void deleteGroupControlPanelLayouts() throws PortalException {
+		for (Long groupControlPanelLayoutPlid :
+			_groupControlPanelPlids.values()) {
+
+			_layoutLocalService.deleteLayout(groupControlPanelLayoutPlid);
+		}
+	}
+
 	@Override
 	protected void doUpgrade() throws Exception {
 		_computeControlPanelPlids();
@@ -54,6 +63,8 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		}
 
 		upgradePortletPreferences();
+
+		deleteGroupControlPanelLayouts();
 	}
 
 	protected void upgradePortletPreferences() throws Exception {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -14,16 +14,70 @@
 
 package com.liferay.fragment.internal.upgrade.v1_1_0;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Ricardo Couso
  */
 public class UpgradePortletPreferences extends UpgradeProcess {
 
+	public UpgradePortletPreferences(LayoutLocalService layoutLocalService) {
+		_layoutLocalService = layoutLocalService;
+	}
+
 	@Override
 	protected void doUpgrade() throws Exception {
+		_computeControlPanelPlids();
 
+		if (_groupControlPanelPlids.isEmpty()) {
+			return;
+		}
 	}
+
+	private void _computeControlPanelPlids() throws Exception {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("select Layout.plid, Group_.groupKey from Layout inner ");
+		sb.append("join Group_ on Layout.groupId = Group_.groupId where ");
+		sb.append("Layout.type_ = '");
+		sb.append(LayoutConstants.TYPE_CONTROL_PANEL);
+		sb.append("';");
+
+		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
+			 ResultSet rs = ps.executeQuery()) {
+
+			while (rs.next()) {
+				String groupKey = rs.getString("groupKey");
+
+				long plid = rs.getLong("plid");
+
+				Layout layout = _layoutLocalService.getLayout(plid);
+
+				if (groupKey.equals(GroupConstants.CONTROL_PANEL)) {
+					_companyControlPanelPlids.put(layout.getCompanyId(), plid);
+				}
+				else {
+					_groupControlPanelPlids.put(layout.getGroupId(), plid);
+				}
+			}
+		}
+	}
+
+	private static final Map<Long, Long> _companyControlPanelPlids =
+		new HashMap<>();
+	private static final Map<Long, Long> _groupControlPanelPlids =
+		new HashMap<>();
+
+	private final LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +49,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 
 	protected void deleteGroupControlPanelLayouts() throws PortalException {
 		for (Long groupControlPanelLayoutPlid :
-			_groupControlPanelPlids.values()) {
+				_groupControlPanelPlids.values()) {
 
 			_layoutLocalService.deleteLayout(groupControlPanelLayoutPlid);
 		}
@@ -69,9 +70,9 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 
 	protected void upgradePortletPreferences() throws Exception {
 		try (PreparedStatement ps = connection.prepareStatement(
-			"select classPK, companyId, groupId, namespace from " +
-			"FragmentEntryLink;");
-			 ResultSet rs = ps.executeQuery()) {
+				"select classPK, companyId, groupId, namespace from " +
+					"FragmentEntryLink;");
+			ResultSet rs = ps.executeQuery()) {
 
 			while (rs.next()) {
 				long classPK = rs.getLong("classPK");
@@ -104,7 +105,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		sb.append("';");
 
 		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
-			 ResultSet rs = ps.executeQuery()) {
+			ResultSet rs = ps.executeQuery()) {
 
 			while (rs.next()) {
 				String groupKey = rs.getString("groupKey");
@@ -131,7 +132,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 	}
 
 	private List<PortletPreferences> _getPortletPreferencesList(
-		long companyId, long groupId, String namespace)
+			long companyId, long groupId, String namespace)
 		throws Exception {
 
 		List<PortletPreferences> portletPreferencesList = new ArrayList<>();
@@ -152,7 +153,7 @@ public class UpgradePortletPreferences extends UpgradeProcess {
 		sb.append(");");
 
 		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
-			 ResultSet rs = ps.executeQuery()) {
+			ResultSet rs = ps.executeQuery()) {
 
 			while (rs.next()) {
 				long portletPreferencesId = rs.getLong("portletPreferencesId");


### PR DESCRIPTION
Hi, 

This is an upgrade step necessary to revert the changes introduced in LPS-97133. 

More precisely, it goes over any portlet preferences associated to frangment entry links and changes the plid they point to from the group control-panel layout (introduced in LPS-97133) to the actual layout the fragment entry link is attached to. 

The last step is to remove these group control-panel layouts since they're only useful in 7.1.x. 

Please let me know if you have any questions. Thanks!