### PR TITLE
Lps 111719

### DIFF
--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -69,42 +69,11 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		_addSubscriptions();
+		_updateSubscriptions();
 
 		if (_deletionMode == DeletionMode.DELETE_OLD) {
 			_deleteSubscriptions();
 		}
-	}
-
-	private void _addSubscriptions() throws IOException, SQLException {
-		String newSubscriptionClassName =
-			MBDiscussion.class.getName() + StringPool.UNDERLINE +
-				_oldSubscriptionClassName;
-
-		long newClassNameId = ClassNameLocalServiceUtil.getClassNameId(
-			newSubscriptionClassName);
-
-		long oldClassNameId = ClassNameLocalServiceUtil.getClassNameId(
-			_oldSubscriptionClassName);
-
-		PreparedStatement ps = connection.prepareStatement(
-			"select classPK from Subscription where classNameId = " +
-				oldClassNameId);
-
-		ResultSet rs = ps.executeQuery();
-
-		while (rs.next()) {
-			long classPK = rs.getLong("classPK");
-
-			_runUpdateSQL(
-				"AssetEntry", true, classPK, oldClassNameId, newClassNameId);
-
-			_runUpdateSQL(
-				"SocialActivity", true, classPK, oldClassNameId,
-				newClassNameId);
-		}
-
-		_runUpdateSQL("Subscription", false, 0, oldClassNameId, newClassNameId);
 	}
 
 	private void _deleteSubscriptions() throws PortalException {
@@ -145,6 +114,37 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		}
 
 		runSQL(sb.toString());
+	}
+
+	private void _updateSubscriptions() throws IOException, SQLException {
+		String newSubscriptionClassName =
+			MBDiscussion.class.getName() + StringPool.UNDERLINE +
+				_oldSubscriptionClassName;
+
+		long newClassNameId = ClassNameLocalServiceUtil.getClassNameId(
+			newSubscriptionClassName);
+
+		long oldClassNameId = ClassNameLocalServiceUtil.getClassNameId(
+			_oldSubscriptionClassName);
+
+		PreparedStatement ps = connection.prepareStatement(
+			"select classPK from Subscription where classNameId = " +
+				oldClassNameId);
+
+		ResultSet rs = ps.executeQuery();
+
+		while (rs.next()) {
+			long classPK = rs.getLong("classPK");
+
+			_runUpdateSQL(
+				"AssetEntry", true, classPK, oldClassNameId, newClassNameId);
+
+			_runUpdateSQL(
+				"SocialActivity", true, classPK, oldClassNameId,
+				newClassNameId);
+		}
+
+		_runUpdateSQL("Subscription", false, 0, oldClassNameId, newClassNameId);
 	}
 
 	private final ClassNameLocalService _classNameLocalService;


### PR DESCRIPTION
Hello @achaparro,

As we discussed this fix updates the existing records related to a subscription rather than creating new ones. This keeps all of the original data the same, the only thing that changes now is the classNameId. We have kept the deletion method since there could be some customers who have used the old method to upgrade discussion class names but did not get to the deletion step yet.

I did test out moving this to a more appropriate module, but I don't believe that is going to work without additional changes to the class and I thought it would be better to do fewer changes to this class as it has already proven to have many issues in the past. This may be one of the cases where we need to make an exception for a module accessing other module's tabes.