### PR TITLE
Lps 113771

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd
@@ -7,7 +7,7 @@ Import-Package:\
 	!org.apache.poi.ss.usermodel.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.2.0
+Liferay-Require-SchemaVersion: 2.2.1
 Liferay-Service: true
 -dsannotations-options: inherit
 -includeresource: @poi-[0-9.]*.jar

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
@@ -24,6 +24,9 @@ import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordSetT
 import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordSetVersionTable;
 import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordTable;
 import com.liferay.dynamic.data.lists.internal.upgrade.v2_0_0.util.DDLRecordVersionTable;
+import com.liferay.dynamic.data.lists.internal.upgrade.v2_2_1.UpgradeEmptyValidation;
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
+import com.liferay.dynamic.data.mapping.io.DDMFormSerializer;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -83,6 +86,11 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 			"2.1.0", "2.2.0",
 			new com.liferay.dynamic.data.lists.internal.upgrade.v2_2_0.
 				UpgradeSchema());
+
+		registry.register(
+			"2.2.0", "2.2.1",
+			new UpgradeEmptyValidation(
+				_jsonDDMFormDeserializer, _jsonDDMFormSerializer));
 	}
 
 	@Reference
@@ -90,5 +98,11 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference(target = "(ddm.form.deserializer.type=json)")
+	private DDMFormDeserializer _jsonDDMFormDeserializer;
+
+	@Reference(target = "(ddm.form.serializer.type=json)")
+	private DDMFormSerializer _jsonDDMFormSerializer;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/DDLServiceUpgrade.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormSerializer;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -82,8 +83,10 @@ public class DDLServiceUpgrade implements UpgradeStepRegistrator {
 			new com.liferay.dynamic.data.lists.internal.upgrade.v2_1_0.
 				UpgradeSchema());
 
+		registry.register("2.1.0", "2.1.1", new DummyUpgradeStep());
+
 		registry.register(
-			"2.1.0", "2.2.0",
+			"2.1.1", "2.2.0",
 			new com.liferay.dynamic.data.lists.internal.upgrade.v2_2_0.
 				UpgradeSchema());
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_2_1/UpgradeEmptyValidation.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/upgrade/v2_2_1/UpgradeEmptyValidation.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.lists.internal.upgrade.v2_2_1;
+
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeRequest;
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeResponse;
+import com.liferay.dynamic.data.mapping.io.DDMFormSerializer;
+import com.liferay.dynamic.data.mapping.io.DDMFormSerializerSerializeRequest;
+import com.liferay.dynamic.data.mapping.io.DDMFormSerializerSerializeResponse;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidation;
+import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidationExpression;
+import com.liferay.dynamic.data.mapping.model.DDMFormRule;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Sam Ziemer
+ */
+public class UpgradeEmptyValidation extends UpgradeProcess {
+
+	public UpgradeEmptyValidation(
+		DDMFormDeserializer ddmFormDeserializer,
+		DDMFormSerializer ddmFormSerializer) {
+
+		_ddmFormDeserializer = ddmFormDeserializer;
+		_ddmFormSerializer = ddmFormSerializer;
+	}
+
+	@Override
+	public void doUpgrade() throws Exception {
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select DDMStructure.definition, DDMStructure.structureId " +
+					"from DDMStructure where classNameId = ? and definition " +
+						"like '%validation%'");
+			PreparedStatement ps2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DDMStructure set definition = ? where " +
+						"structureId = ?")) {
+
+			long classNameId = PortalUtil.getClassNameId(
+				"com.liferay.dynamic.data.lists.model.DDLRecordSet");
+
+			ps1.setLong(1, classNameId);
+
+			try (ResultSet rs = ps1.executeQuery()) {
+				while (rs.next()) {
+					String definition = rs.getString(1);
+
+					String newDefinition = _updateEmptyValidation(definition);
+
+					if (newDefinition.equals(definition)) {
+						continue;
+					}
+
+					long structureId = rs.getLong(2);
+
+					ps2.setString(1, newDefinition);
+
+					ps2.setLong(2, structureId);
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
+	}
+
+	private String _updateEmptyValidation(String definition) {
+		DDMFormDeserializerDeserializeRequest.Builder deserializerBuilder =
+			DDMFormDeserializerDeserializeRequest.Builder.newBuilder(
+				definition);
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse =
+				_ddmFormDeserializer.deserialize(deserializerBuilder.build());
+
+		DDMForm ddmForm = ddmFormDeserializerDeserializeResponse.getDDMForm();
+
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmForm.getDDMFormFieldsMap(true);
+
+		List<DDMFormRule> ddmFormRules = ddmForm.getDDMFormRules();
+
+		List<DDMFormField> ddmformfieldsList = new ArrayList<>();
+
+		for (DDMFormField ddmFormField : ddmFormFieldsMap.values()) {
+			DDMFormFieldValidation ddmFormFieldValidation =
+				ddmFormField.getDDMFormFieldValidation();
+
+			if (ddmFormFieldValidation != null) {
+				DDMFormFieldValidationExpression
+					ddmFormFieldValidationExpression =
+						ddmFormFieldValidation.
+							getDDMFormFieldValidationExpression();
+
+				String name = ddmFormFieldValidationExpression.getName();
+				String value = ddmFormFieldValidationExpression.getValue();
+
+				if (name.isEmpty() && value.isEmpty()) {
+					ddmFormField.setDDMFormFieldValidation(null);
+				}
+			}
+
+			ddmformfieldsList.add(ddmFormField);
+		}
+
+		ddmForm.setDDMFormRules(ddmFormRules);
+
+		ddmForm.setDDMFormFields(ddmformfieldsList);
+
+		DDMFormSerializerSerializeRequest.Builder serializerBuilder =
+			DDMFormSerializerSerializeRequest.Builder.newBuilder(ddmForm);
+
+		DDMFormSerializerSerializeResponse ddmFormSerializerSerializeResponse =
+			_ddmFormSerializer.serialize(serializerBuilder.build());
+
+		return ddmFormSerializerSerializeResponse.getContent();
+	}
+
+	private final DDMFormDeserializer _ddmFormDeserializer;
+	private final DDMFormSerializer _ddmFormSerializer;
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113771

Hello @achaparro,

The issue in this ticket is in 7.0 we add validation to data definition objects but we do not fill it with anything. During the upgrade that validation string is turned from this:

"validation":{}

to this:

"validation":{"expression":{"name":"","value":""},"parameter":{},"errorMessage":{}}

Post upgrade, when adding a new record to the DDL using that definition, the validation express fails to compile and throws an exception. In 7.2 and master, when creating a DDL, if there is no validation added in the definition, then it is not added to the definition string stored in the database. Let me know if you have any questions.