### PR TITLE
LPS-114083 Ensure we have unique names before inserting into LayoutPa…

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.sql.PreparedStatement;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -74,6 +75,8 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				_layoutPrototypeLocalService.getLayoutPrototypes(
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
+			List<String> existingNames = new ArrayList<>();
+
 			for (LayoutPrototype layoutPrototype : layoutPrototypes) {
 				Date createDate = layoutPrototype.getCreateDate();
 				String nameXML = layoutPrototype.getName();
@@ -87,6 +90,26 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				Locale defaultLocale = LocaleUtil.fromLanguageId(
 					LocalizationUtil.getDefaultLanguageId(nameXML));
 
+				String name = nameMap.get(defaultLocale);
+
+				if (existingNames.contains(name)) {
+					while (true) {
+						int i = 1;
+
+						name = name + i;
+
+						if (existingNames.contains(name)) {
+							i++;
+
+							continue;
+						}
+
+						break;
+					}
+				}
+
+				existingNames.add(name);
+
 				ps.setString(1, layoutPrototype.getUuid());
 				ps.setLong(2, increment());
 				ps.setLong(3, company.getGroupId());
@@ -96,7 +119,7 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				ps.setDate(7, new java.sql.Date(createDate.getTime()));
 				ps.setDate(8, new java.sql.Date(createDate.getTime()));
 				ps.setLong(9, 0);
-				ps.setString(10, nameMap.get(defaultLocale));
+				ps.setString(10, name);
 				ps.setInt(
 					11, LayoutPageTemplateEntryTypeConstants.TYPE_WIDGET_PAGE);
 				ps.setLong(12, layoutPrototype.getLayoutPrototypeId());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-114083

This change reflects a similar, but slightly different logic we have when adding [friendlyURLs for layouts](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutFriendlyURLStagedModelDataHandler.java#L173-L206).

Some questions I still have regarding this fix, however.

1. The name for LayoutPageTemplateEntry is pulled from LayoutPrototypes, if we update the name for the LayoutPageTemplateEntry, should we also update the LayoutPrototypes to the same name (including adding the number to the name for each locale)?
2. The index that requires unique was added in https://issues.liferay.com/browse/LPS-85497 but I do not see any specific reasons it needs to be unique. Another route for fixing would be to remove unique from the index.