### PR TITLE
LPS-115694 Add groupId to the GroupThreadLocal and use it to ensure w…

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.service.permission.LayoutSetPrototypePermission
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -396,14 +397,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 	protected void addTeamRoles(long userId, Group group, Set<Long> roleIds)
 		throws Exception {
 
-		int count = TeamLocalServiceUtil.getGroupTeamsCount(group.getGroupId());
+		long groupId = GroupThreadLocal.getGroupId();
+
+		int count = TeamLocalServiceUtil.getGroupTeamsCount(groupId);
 
 		if (count == 0) {
 			return;
 		}
 
 		List<Role> roles = RoleLocalServiceUtil.getUserTeamRoles(
-			userId, group.getGroupId());
+			userId, groupId);
 
 		for (Role role : roles) {
 			roleIds.add(role.getRoleId());

--- a/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 
 import java.util.Map;
 import java.util.Objects;
@@ -110,12 +111,21 @@ public class StagingPermissionChecker implements PermissionChecker {
 			primKey = liveGroup.getGroupId();
 		}
 
-		if (_isStagingFolder(name, actionId)) {
-			return true;
-		}
+		long previousGroupId = GroupThreadLocal.getGroupId();
 
-		return _permissionChecker.hasPermission(
-			liveGroup, name, primKey, actionId);
+		GroupThreadLocal.setGroupId(group.getGroupId());
+
+		try {
+			if (_isStagingFolder(name, actionId)) {
+				return true;
+			}
+
+			return _permissionChecker.hasPermission(
+				liveGroup, name, primKey, actionId);
+		}
+		finally {
+			GroupThreadLocal.setGroupId(previousGroupId);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/StagingPermissionChecker.java
@@ -113,7 +113,9 @@ public class StagingPermissionChecker implements PermissionChecker {
 
 		long previousGroupId = GroupThreadLocal.getGroupId();
 
-		GroupThreadLocal.setGroupId(group.getGroupId());
+		if (group != null) {
+			GroupThreadLocal.setGroupId(group.getGroupId());
+		}
 
 		try {
 			if (_isStagingFolder(name, actionId)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-115694

Use the GroupThreadLocal to make sure we are checking the correct group for team roles.