### PR TITLE
[TS] LPS-116699 Specify schema name when querying indexes

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -16,6 +16,7 @@ package com.liferay.portal.dao.db;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
@@ -113,10 +114,15 @@ public class PostgreSQLDB extends BaseDB {
 	public List<Index> getIndexes(Connection con) throws SQLException {
 		List<Index> indexes = new ArrayList<>();
 
-		StringBundler sb = new StringBundler(2);
+		DBInspector dbInspector = new DBInspector(con);
+
+		StringBundler sb = new StringBundler(5);
 
 		sb.append("select indexname, tablename, indexdef from pg_indexes ");
-		sb.append("where indexname like 'liferay_%' or indexname like 'ix_%'");
+		sb.append("where schemaname = '");
+		sb.append(dbInspector.getSchema());
+		sb.append("' and (indexname like 'liferay_%' or indexname like ");
+		sb.append("'ix_%')");
 
 		String sql = sb.toString();
 


### PR DESCRIPTION
[LPS-116699](https://issues.liferay.com/browse/LPS-116699)

Hi Alberto,

I hope you can review my changes.

The issue occurs when storing multiple Liferay portal schema in a single PostgreSQL database and upgrading one of the portal schemas. During the upgrade process some indexes are dropped. Later on, the verify process also selects indexes for dropping. The problem is that we don't specify the schema name from which to query the indexes, so we get back indexes already deleted from the current schema but still existing in other portal schema(s). Apparently, the attempt of dropping non-existent indexes fails.

Please let me know if you have any questions or concerns.

Thank you,
Istvan