### PR TITLE
LPS-118138 Upgrade: Do not need to disable index 2

### DIFF
--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/configuration/VerifyProcessTrackerConfiguration.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/configuration/VerifyProcessTrackerConfiguration.java
@@ -32,6 +32,10 @@ public interface VerifyProcessTrackerConfiguration {
 	@Meta.AD(deflt = "true", name = "auto-verify", required = false)
 	public boolean autoVerify();
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	@Meta.AD(deflt = "true", name = "index-read-only", required = false)
 	public boolean indexReadOnly();
 

--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -248,11 +248,6 @@ public class VerifyProcessTrackerOSGiCommands {
 		List<VerifyProcess> verifyProcesses = getVerifyProcesses(
 			verifyProcessTrackerMap, verifyProcessName);
 
-		boolean indexReadOnly = indexStatusManager.isIndexReadOnly();
-
-		indexStatusManager.setIndexReadOnly(
-			_verifyProcessTrackerConfiguration.indexReadOnly());
-
 		NotificationThreadLocal.setEnabled(false);
 		StagingAdvicesThreadLocal.setEnabled(false);
 		WorkflowThreadLocal.setEnabled(false);
@@ -313,7 +308,6 @@ public class VerifyProcessTrackerOSGiCommands {
 			}
 		}
 		finally {
-			indexStatusManager.setIndexReadOnly(indexReadOnly);
 			NotificationThreadLocal.setEnabled(true);
 			StagingAdvicesThreadLocal.setEnabled(true);
 			WorkflowThreadLocal.setEnabled(true);

--- a/portal-impl/src/com/liferay/portal/service/impl/ReleaseLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ReleaseLocalServiceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.ReleaseLocalServiceBaseImpl;
-import com.liferay.portal.util.PropsValues;
 
 import java.util.Date;
 import java.util.List;
@@ -171,7 +170,7 @@ public class ReleaseLocalServiceImpl extends ReleaseLocalServiceBaseImpl {
 	@Override
 	public void updateRelease(
 			String servletContextName, List<UpgradeProcess> upgradeProcesses,
-			int buildNumber, int previousBuildNumber, boolean indexOnUpgrade)
+			int buildNumber, int previousBuildNumber)
 		throws PortalException {
 
 		if (buildNumber <= 0) {
@@ -203,12 +202,28 @@ public class ReleaseLocalServiceImpl extends ReleaseLocalServiceBaseImpl {
 		}
 		else {
 			UpgradeProcessUtil.upgradeProcess(
-				release.getBuildNumber(), upgradeProcesses, indexOnUpgrade);
+				release.getBuildNumber(), upgradeProcesses);
 		}
 
 		releaseLocalService.updateRelease(
 			release.getReleaseId(), release.getSchemaVersion(), buildNumber,
 			null, true);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 * 				#updateRelease(String, List, int, int)}
+	 */
+	@Deprecated
+	@Override
+	public void updateRelease(
+			String servletContextName, List<UpgradeProcess> upgradeProcesses,
+			int buildNumber, int previousBuildNumber, boolean indexOnUpgrade)
+		throws PortalException {
+
+		updateRelease(
+			servletContextName, upgradeProcesses, buildNumber,
+			previousBuildNumber);
 	}
 
 	@Override
@@ -226,13 +241,9 @@ public class ReleaseLocalServiceImpl extends ReleaseLocalServiceBaseImpl {
 				PropsKeys.RELEASE_INFO_PREVIOUS_BUILD_NUMBER),
 			buildNumber);
 
-		boolean indexOnUpgrade = GetterUtil.getBoolean(
-			unfilteredPortalProperties.getProperty(PropsKeys.INDEX_ON_UPGRADE),
-			PropsValues.INDEX_ON_UPGRADE);
-
 		updateRelease(
 			servletContextName, upgradeProcesses, buildNumber,
-			previousBuildNumber, indexOnUpgrade);
+			previousBuildNumber);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1126,6 +1126,10 @@ public class PropsValues {
 	public static final int INDEX_ON_STARTUP_DELAY = GetterUtil.getInteger(
 		PropsUtil.get(PropsKeys.INDEX_ON_STARTUP_DELAY));
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final boolean INDEX_ON_UPGRADE = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.INDEX_ON_UPGRADE));
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1713,7 +1713,7 @@ public class VerifyProperties extends VerifyProcess {
 		"hibernate.cache.use_minimal_puts", "hibernate.cache.use_query_cache",
 		"hibernate.cache.use_second_level_cache",
 		"hibernate.cache.use_structured_entries", "icq.jar", "icq.login",
-		"icq.password", "index.filter.search.limit",
+		"icq.password", "index.filter.search.limit", "index.on.upgrade",
 		"index.portal.field.analyzer.enabled", "index.search.highlight.enabled",
 		"index.read.only", "invitation.email.max.recipients",
 		"invitation.email.message.body", "invitation.email.message.subject",

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5758,15 +5758,6 @@
     index.on.startup.delay=60
 
     #
-    # Set this to true if you want to index your entire library of files after
-    # an upgrade. Only set this property to false if you are running a small
-    # upgrade and you do not need to reindex everything.
-    #
-    # Env: LIFERAY_INDEX_PERIOD_ON_PERIOD_UPGRADE
-    #
-    index.on.upgrade=true
-
-    #
     # Set this to true if you want the indexing on startup to be executed on a
     # separate thread to speed up execution.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ReleaseLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ReleaseLocalService.java
@@ -60,7 +60,7 @@ public interface ReleaseLocalService
 	/*
 	 * NOTE FOR DEVELOPERS:
 	 *
-	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.service.impl.ReleaseLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the release local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link ReleaseLocalServiceUtil} if injection and service tracking are not available.
+	 * Never modify or reference this interface directly. Always use {@link ReleaseLocalServiceUtil} to access the release local service. Add custom service methods to <code>com.liferay.portal.service.impl.ReleaseLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
 
 	/**
@@ -288,6 +288,16 @@ public interface ReleaseLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public Release updateRelease(Release release);
 
+	public void updateRelease(
+			String servletContextName, List<UpgradeProcess> upgradeProcesses,
+			int buildNumber, int previousBuildNumber)
+		throws PortalException;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #updateRelease(String, List, int, int)}
+	 */
+	@Deprecated
 	public void updateRelease(
 			String servletContextName, List<UpgradeProcess> upgradeProcesses,
 			int buildNumber, int previousBuildNumber, boolean indexOnUpgrade)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ReleaseLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ReleaseLocalServiceUtil.java
@@ -353,6 +353,23 @@ public class ReleaseLocalServiceUtil {
 			String servletContextName,
 			java.util.List<com.liferay.portal.kernel.upgrade.UpgradeProcess>
 				upgradeProcesses,
+			int buildNumber, int previousBuildNumber)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		getService().updateRelease(
+			servletContextName, upgradeProcesses, buildNumber,
+			previousBuildNumber);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #updateRelease(String, List, int, int)}
+	 */
+	@Deprecated
+	public static void updateRelease(
+			String servletContextName,
+			java.util.List<com.liferay.portal.kernel.upgrade.UpgradeProcess>
+				upgradeProcesses,
 			int buildNumber, int previousBuildNumber, boolean indexOnUpgrade)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ReleaseLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ReleaseLocalServiceWrapper.java
@@ -367,6 +367,24 @@ public class ReleaseLocalServiceWrapper
 			java.lang.String servletContextName,
 			java.util.List<com.liferay.portal.kernel.upgrade.UpgradeProcess>
 				upgradeProcesses,
+			int buildNumber, int previousBuildNumber)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_releaseLocalService.updateRelease(
+			servletContextName, upgradeProcesses, buildNumber,
+			previousBuildNumber);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 #updateRelease(String, List, int, int)}
+	 */
+	@Deprecated
+	@Override
+	public void updateRelease(
+			java.lang.String servletContextName,
+			java.util.List<com.liferay.portal.kernel.upgrade.UpgradeProcess>
+				upgradeProcesses,
 			int buildNumber, int previousBuildNumber, boolean indexOnUpgrade)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java
@@ -17,13 +17,9 @@ package com.liferay.portal.kernel.upgrade.util;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -117,37 +113,31 @@ public class UpgradeProcessUtil {
 			int buildNumber, List<UpgradeProcess> upgradeProcesses)
 		throws UpgradeException {
 
-		return upgradeProcess(buildNumber, upgradeProcesses, _INDEX_ON_UPGRADE);
+		boolean ranUpgradeProcess = false;
+
+		for (UpgradeProcess upgradeProcess : upgradeProcesses) {
+			boolean tempRanUpgradeProcess = _upgradeProcess(
+				buildNumber, upgradeProcess);
+
+			if (tempRanUpgradeProcess) {
+				ranUpgradeProcess = true;
+			}
+		}
+
+		return ranUpgradeProcess;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *			 #upgradeProcess(int, List)} ()}
+	 */
+	@Deprecated
 	public static boolean upgradeProcess(
 			int buildNumber, List<UpgradeProcess> upgradeProcesses,
 			boolean indexOnUpgrade)
 		throws UpgradeException {
 
-		boolean ranUpgradeProcess = false;
-
-		boolean tempIndexReadOnly = IndexWriterHelperUtil.isIndexReadOnly();
-
-		if (indexOnUpgrade) {
-			IndexWriterHelperUtil.setIndexReadOnly(true);
-		}
-
-		try {
-			for (UpgradeProcess upgradeProcess : upgradeProcesses) {
-				boolean tempRanUpgradeProcess = _upgradeProcess(
-					buildNumber, upgradeProcess);
-
-				if (tempRanUpgradeProcess) {
-					ranUpgradeProcess = true;
-				}
-			}
-		}
-		finally {
-			IndexWriterHelperUtil.setIndexReadOnly(tempIndexReadOnly);
-		}
-
-		return ranUpgradeProcess;
+		return upgradeProcess(buildNumber, upgradeProcesses);
 	}
 
 	private static boolean _upgradeProcess(
@@ -182,9 +172,6 @@ public class UpgradeProcessUtil {
 
 		return false;
 	}
-
-	private static final boolean _INDEX_ON_UPGRADE = GetterUtil.getBoolean(
-		PropsUtil.get(PropsKeys.INDEX_ON_UPGRADE));
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeProcessUtil.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1274,6 +1274,10 @@ public interface PropsKeys {
 	public static final String INDEX_ON_STARTUP_DELAY =
 		"index.on.startup.delay";
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String INDEX_ON_UPGRADE = "index.on.upgrade";
 
 	public static final String


### PR DESCRIPTION
Hey @brianchandotcom,

From https://github.com/brianchandotcom/liferay-portal/pull/92105#issuecomment-667472109

I can only remove the property _index.on.upgrade_, the other two suggested properties are still in use and they make sense.

Thanks.

@xbrianlee