### PR TITLE
LPS-119275 Add a CAST_TEXT to preferences column to avoid problems with SYBASE database

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -223,9 +223,9 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 		runSQL(
 			StringBundler.concat(
 				"update PortletPreferences set preferences = replace(",
-				"preferences, '#portlet_", oldRootPortletId, "', '#portlet_",
-				newRootPortletId, "') where portletId = '", newRootPortletId,
-				"'"));
+				"CAST_TEXT(preferences), '#portlet_", oldRootPortletId,
+				"', '#portlet_", newRootPortletId, "') where portletId = '",
+				newRootPortletId, "'"));
 
 		if (!newRootPortletId.contains("_INSTANCE_")) {
 			runSQL(
@@ -238,9 +238,10 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 			runSQL(
 				StringBundler.concat(
 					"update PortletPreferences set preferences = replace(",
-					"preferences, '#portlet_", oldRootPortletId, "_INSTANCE_',",
-					"'#portlet_", newRootPortletId, "_INSTANCE_') where ",
-					"portletId like '", newRootPortletId, "_INSTANCE_%'"));
+					"CAST_TEXT(preferences), '#portlet_", oldRootPortletId,
+					"_INSTANCE_','#portlet_", newRootPortletId,
+					"_INSTANCE_') where portletId like '", newRootPortletId,
+					"_INSTANCE_%'"));
 		}
 
 		runSQL(
@@ -253,9 +254,9 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 		runSQL(
 			StringBundler.concat(
 				"update PortletPreferences set preferences = replace(",
-				"preferences, '#portlet_", oldRootPortletId, "_USER_', ",
-				"'#portlet_", newRootPortletId, "_USER_') where portletId ",
-				"like '", newRootPortletId, "_USER_%'"));
+				"CAST_TEXT(preferences), '#portlet_", oldRootPortletId,
+				"_USER_', '#portlet_", newRootPortletId, "_USER_') where ",
+				"portletId like '", newRootPortletId, "_USER_%'"));
 	}
 
 	protected void updateLayout(long plid, String typeSettings)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-119275

Regression caused by the upgrade added in https://issues.liferay.com/browse/LPS-118902

It seems it is a SYBASE limitation that is solved adding a CAST_TEXT to the preferences column.

I have applied same solution than https://issues.liferay.com/browse/LPS-95571

/cc @ricardocousolr 