### PR TITLE
LPS-118989 UpgradeResourcePermission fails with ORA-01795

### DIFF
--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.15.1
+Bundle-Version: 5.15.2
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -16,9 +16,13 @@ package com.liferay.portal.upgrade.v7_0_0;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 
 import java.sql.PreparedStatement;
@@ -90,6 +94,20 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 		}
 	}
 
+	private String _createInClause(List<String> primKeys) {
+		StringBundler sb = new StringBundler(primKeys.size() + 1);
+
+		sb.append("in (?");
+
+		for (int i = 1; i < primKeys.size(); i++) {
+			sb.append(", ?");
+		}
+
+		sb.append(")");
+
+		return sb.toString();
+	}
+
 	private void _updatePrimKeyIds(
 			String sql, String name, List<String> primKeys)
 		throws Exception {
@@ -126,30 +144,54 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			return;
 		}
 
-		StringBundler sb = new StringBundler(primKeys.size() + 1);
+		DB db = DBManagerUtil.getDB();
 
-		sb.append("in (?");
+		if ((db.getDBType() == DBType.ORACLE) && (primKeys.size() > 1000)) {
+			_updatePrimKeyIdsInBatches(name, primKeys);
+		}
+		else {
+			String inClause = _createInClause(primKeys);
 
-		for (int i = 1; i < primKeys.size(); i++) {
-			sb.append(", ?");
+			_updatePrimKeyIds(
+				StringBundler.concat(
+					"update ResourcePermission set primKeyId = 0 where name = ",
+					"? and (primKey like '%_LAYOUT_%' or primKey ", inClause,
+					")"),
+				name, primKeys);
 		}
 
-		sb.append(")");
-
-		String inClause = sb.toString();
-
-		_updatePrimKeyIds(
-			StringBundler.concat(
-				"update ResourcePermission set primKeyId = 0 where name = ? ",
-				"and (primKey like '%_LAYOUT_%' or primKey ", inClause, ")"),
-			name, primKeys);
-
-		_updatePrimKeyIds(
+		runSQL(
 			StringBundler.concat(
 				"update ResourcePermission set primKeyId = CAST_LONG(primKey",
-				") where name = ? and (primKey not like '%_LAYOUT_%' and ",
-				"primKey not ", inClause, ")"),
-			name, primKeys);
+				") where name = '", name,
+				"' and (primKey not like '%_LAYOUT_%' and primKeyId != 0)"));
+	}
+
+	private void _updatePrimKeyIdsInBatches(String name, List<String> primKeys)
+		throws Exception {
+
+		int iteration = primKeys.size() / 1000;
+
+		for (int i = 0; i <= iteration; i++) {
+			int start = i * 1000;
+
+			int end = start + 1000;
+
+			if (end > primKeys.size()) {
+				end = primKeys.size();
+			}
+
+			List<String> sublist = ListUtil.subList(primKeys, start, end);
+
+			String inClause = _createInClause(sublist);
+
+			_updatePrimKeyIds(
+				StringBundler.concat(
+					"update ResourcePermission set primKeyId = 0 where name = ",
+					"? and (primKey like '%_LAYOUT_%' or primKey ", inClause,
+					")"),
+				name, sublist);
+		}
 	}
 
 }


### PR DESCRIPTION
[LPS-118989](https://issues.liferay.com/browse/LPS-118989)

Hi Alberto,

I hope you can review my changes.

**Issue**: Oracle has a limitation that prevents adding too many (> 1000) expressions to a list. This may cause problems for custom entities using string primKeys not convertible to long, resulting in "ORA-01795: maximum number of expressions in a list is 1000" error.

The error occurs if the inClause variable contains more than 1000 primKeys: https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java#L129-L145

Based on [Sam's advice](https://github.com/SamZiemer/liferay-portal-ee/pull/444#issuecomment-674165876), update will happen in batches for Oracle DB with more than 1000 primKeys.

Thank you,
Istvan
