### PR TITLE
 [TS] LPS-122913 Remove old CalEvent classNameId entries from Subscription table

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v1_0_4/UpgradeClassNames.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v1_0_4/UpgradeClassNames.java
@@ -64,6 +64,10 @@ public class UpgradeClassNames extends UpgradeKernelPackage {
 			runSQL(
 				"delete from ResourcePermission where name like '" +
 					_CLASS_NAME_CAL_EVENT + "%'");
+
+			runSQL(
+				"delete from Subscription where classNameId = " +
+					PortalUtil.getClassNameId(_CLASS_NAME_CAL_EVENT));
 		}
 		catch (Exception exception) {
 			throw new UpgradeException(exception);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122913

This is similar to https://issues.liferay.com/browse/LPS-112455 changes, just deleting the old CalEvent entries from Subscription table