### PR TITLE
LPS-118793 UpgradeStep for VirtualHost fails since column already exists

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/UpgradeVirtualHost.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/UpgradeVirtualHost.java
@@ -23,11 +23,15 @@ public class UpgradeVirtualHost extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		runSQL("alter table VirtualHost add defaultVirtualHost BOOLEAN;");
+		if (!hasColumn("VirtualHost", "defaultVirtualHost")) {
+			runSQL("alter table VirtualHost add defaultVirtualHost BOOLEAN;");
 
-		runSQL("alter table VirtualHost add languageId VARCHAR(75) null;");
+			runSQL("update VirtualHost set defaultVirtualHost = TRUE;");
+		}
 
-		runSQL("update VirtualHost set defaultVirtualHost = TRUE;");
+		if (!hasColumn("VirtualHost", "languageId")) {
+			runSQL("alter table VirtualHost add languageId VARCHAR(75) null;");
+		}
 	}
 
 }


### PR DESCRIPTION
Hi,

This solution is based on https://github.com/liferay/liferay-portal-ee/blob/ec3dfe1e562a90abf9f035e2cc3d539b41a1d9d4/modules/apps/portal/portal-virtual-host-impl/src/main/java/com/liferay/portal/virtual/host/internal/activator/PortalVirtualHostImplBundleActivator.java#L46-L51

Please review,

Thanks,
László