### PR TITLE
LPS-125637 #p_p_id portlet references in custom css are not upgraded from 6.2

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/upgrade/v1_1_1/UpgradeEventsDisplayPortletId.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/upgrade/v1_1_1/UpgradeEventsDisplayPortletId.java
@@ -132,7 +132,6 @@ public class UpgradeEventsDisplayPortletId extends BaseUpgradePortletId {
 
 				dynamicQuery.add(junction);
 			});
-		actionableDynamicQuery.setParallel(true);
 		actionableDynamicQuery.setPerformActionMethod(
 			(PortletPreferences portletPreference) -> updatePortletPreferences(
 				portletPreference, oldRootPortletId, newRootPortletId));

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
@@ -132,7 +132,6 @@ public class UpgradeDDLFormPortletId extends BaseUpgradePortletId {
 
 				dynamicQuery.add(junction);
 			});
-		actionableDynamicQuery.setParallel(true);
 		actionableDynamicQuery.setPerformActionMethod(
 			(PortletPreferences portletPreference) -> updatePortletPreferences(
 				portletPreference, oldRootPortletId, newRootPortletId));

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
@@ -186,6 +186,10 @@ public class UpgradeDDLFormPortletId extends BaseUpgradePortletId {
 				"</preference></portlet-preferences>");
 
 		newPreferences = StringUtil.replace(
+			newPreferences, "#p_p_id_" + oldRootPortletId,
+			"#p_p_id_" + newRootPortletId);
+
+		newPreferences = StringUtil.replace(
 			newPreferences, "#portlet_" + oldRootPortletId,
 			"#portlet_" + newRootPortletId);
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
@@ -186,12 +186,13 @@ public class UpgradeDDLFormPortletId extends BaseUpgradePortletId {
 				"</preference></portlet-preferences>");
 
 		newPreferences = StringUtil.replace(
-			newPreferences, "#p_p_id_" + oldRootPortletId,
-			"#p_p_id_" + newRootPortletId);
-
-		newPreferences = StringUtil.replace(
-			newPreferences, "#portlet_" + oldRootPortletId,
-			"#portlet_" + newRootPortletId);
+			newPreferences,
+			new String[] {
+				"#p_p_id_" + oldRootPortletId, "#portlet_" + oldRootPortletId
+			},
+			new String[] {
+				"#p_p_id_" + newRootPortletId, "#portlet_" + newRootPortletId
+			});
 
 		_portletPreferencesLocalService.updatePreferences(
 			portletPreferences.getOwnerId(), portletPreferences.getOwnerType(),

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
@@ -170,8 +170,9 @@ public class UpgradeDDLFormPortletId extends BaseUpgradePortletId {
 
 		portletPreferences.setPortletId(newPortletId);
 
-		_portletPreferencesLocalService.updatePortletPreferences(
-			portletPreferences);
+		portletPreferences =
+			_portletPreferencesLocalService.updatePortletPreferences(
+				portletPreferences);
 
 		String oldPreferences = PortletPreferencesFactoryUtil.toXML(
 			_portletPreferencesLocalService.getPreferences(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
@@ -140,12 +140,13 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 		newPortletPreferences.setValue("paginationType", "none");
 
 		portletSetupCss = StringUtil.replace(
-			portletSetupCss, "#p_p_id_" + oldRootPortletId,
-			"#p_p_id_" + newRootPortletId);
-
-		portletSetupCss = StringUtil.replace(
-			portletSetupCss, "#portlet_" + oldRootPortletId,
-			"#portlet_" + newRootPortletId);
+			portletSetupCss,
+			new String[] {
+				"#p_p_id_" + oldRootPortletId, "#portlet_" + oldRootPortletId
+			},
+			new String[] {
+				"#p_p_id_" + newRootPortletId, "#portlet_" + newRootPortletId
+			});
 
 		newPortletPreferences.setValue("portletSetupCss", portletSetupCss);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
@@ -214,9 +214,9 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 
 		StringBundler sb = new StringBundler(11);
 
-		sb.append("select PortletPreferences.portletPreferencesId from ");
-		sb.append("PortletPreferences inner join PortletPreferenceValue on ");
-		sb.append("PortletPreferenceValue.portletPreferencesId = ");
+		sb.append("select distinct PortletPreferences.portletPreferencesId ");
+		sb.append("from PortletPreferences inner join PortletPreferenceValue ");
+		sb.append("on PortletPreferenceValue.portletPreferencesId = ");
 		sb.append("PortletPreferences.portletPreferencesId where portletId = ");
 		sb.append("'");
 		sb.append(oldRootPortletId);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
@@ -140,6 +140,10 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 		newPortletPreferences.setValue("paginationType", "none");
 
 		portletSetupCss = StringUtil.replace(
+			portletSetupCss, "#p_p_id_" + oldRootPortletId,
+			"#p_p_id_" + newRootPortletId);
+
+		portletSetupCss = StringUtil.replace(
 			portletSetupCss, "#portlet_" + oldRootPortletId,
 			"#portlet_" + newRootPortletId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -337,12 +337,15 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 					}
 
 					String newValue = StringUtil.replace(
-						value, "#p_p_id_" + oldRootPortletId,
-						"#p_p_id_" + newRootPortletId);
-
-					newValue = StringUtil.replace(
-						newValue, "#portlet_" + oldRootPortletId,
-						"#portlet_" + newRootPortletId);
+						value,
+						new String[] {
+							"#p_p_id_" + oldRootPortletId,
+							"#portlet_" + oldRootPortletId
+						},
+						new String[] {
+							"#p_p_id_" + newRootPortletId,
+							"#portlet_" + newRootPortletId
+						});
 
 					if (Objects.equals(value, newValue)) {
 						continue;

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -355,10 +355,10 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 					String smallValue = null;
 
 					if (newValue.length() > smallValueMaxLength) {
-						largeValue = value;
+						largeValue = newValue;
 					}
 					else {
-						smallValue = value;
+						smallValue = newValue;
 					}
 
 					updatePreparedStatement.setString(1, largeValue);

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -312,11 +312,11 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 				"PortletPreferenceValue inner join PortletPreferences on ",
 				"PortletPreferences.portletPreferencesId = ",
 				"PortletPreferenceValue.portletPreferencesId where ",
-				"PortletPreferences.portletId = '", newRootPortletId,
+				"(PortletPreferences.portletId = '", newRootPortletId,
 				"' or PortletPreferences.portletId like '", newRootPortletId,
 				"_INSTANCE_%' or PortletPreferences.portletId like '",
-				newRootPortletId,
-				"_USER_%' and PortletPreferenceValue.name = 'portletSetupCss'");
+				newRootPortletId, "_USER_%') and PortletPreferenceValue.name ",
+				"= 'portletSetupCss'");
 
 			String updateSQL =
 				"update PortletPreferenceValue set largeValue = ?, " +

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -256,6 +256,13 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 			runSQL(
 				StringBundler.concat(
 					"update PortletPreferences set preferences = replace(",
+					preferencesExpression, ", '#p_p_id_", oldRootPortletId,
+					"', '#p_p_id_", newRootPortletId, "') where portletId = '",
+					newRootPortletId, "'"));
+
+			runSQL(
+				StringBundler.concat(
+					"update PortletPreferences set preferences = replace(",
 					preferencesExpression, ", '#portlet_", oldRootPortletId,
 					"', '#portlet_", newRootPortletId, "') where portletId = '",
 					newRootPortletId, "'"));
@@ -264,11 +271,27 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 				runSQL(
 					StringBundler.concat(
 						"update PortletPreferences set preferences = replace(",
+						preferencesExpression, ", '#p_p_id_", oldRootPortletId,
+						"_INSTANCE_', '#p_p_id_", newRootPortletId,
+						"_INSTANCE_') where portletId like '", newRootPortletId,
+						"_INSTANCE_%'"));
+
+				runSQL(
+					StringBundler.concat(
+						"update PortletPreferences set preferences = replace(",
 						preferencesExpression, ", '#portlet_", oldRootPortletId,
 						"_INSTANCE_', '#portlet_", newRootPortletId,
 						"_INSTANCE_') where portletId like '", newRootPortletId,
 						"_INSTANCE_%'"));
 			}
+
+			runSQL(
+				StringBundler.concat(
+					"update PortletPreferences set preferences = replace(",
+					preferencesExpression, ", '#p_p_id_", oldRootPortletId,
+					"_USER_', '#p_p_id_", newRootPortletId,
+					"_USER_') where portletId like '", newRootPortletId,
+					"_USER_%'"));
 
 			runSQL(
 				StringBundler.concat(
@@ -314,7 +337,11 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 					}
 
 					String newValue = StringUtil.replace(
-						value, "#portlet_" + oldRootPortletId,
+						value, "#p_p_id_" + oldRootPortletId,
+						"#p_p_id_" + newRootPortletId);
+
+					newValue = StringUtil.replace(
+						newValue, "#portlet_" + oldRootPortletId,
 						"#portlet_" + newRootPortletId);
 
 					if (Objects.equals(value, newValue)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-125637

**Implementation notes**

- This issue is similar to https://issues.liferay.com/browse/LPS-118902 but instead of replacing the portletId in the `#portlet_` styles, we have to also replace it in the `#p_p_id_` styles
- After the https://issues.liferay.com/browse/LPS-122562 code changes, it is also necessary to do some additional changes in the BaseUpgradePortletId class, see https://github.com/achaparro/liferay-portal/commit/7d887de6c293b0ec8f216c0cf34e05ed072fa924#diff-fe9beec00e5996c4155b9fc06f206351c6aadb200d925d7b57b3df41b3686feaR339-R344
- I have also have some problems with the https://issues.liferay.com/browse/LPS-122562 code changes, after that LPS the upgrade is not working correctly, I have applied some commits in order to be able to test my changes, see: https://github.com/achaparro/liferay-portal/commit/f050e0db877a530b63c24e40d33c172443541061, https://github.com/achaparro/liferay-portal/commit/5d6737e76b7b47aedb7bf2595118c82d48ba7c65, https://github.com/achaparro/liferay-portal/commit/f44ad154838a4135f0362510abdf8f42a406f393 and https://github.com/achaparro/liferay-portal/commit/2601d1bfbbae792e9cb598b7f5d58feefea997f2