### PR TITLE
LPS-124848 Using an SQL has better performance

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -72,8 +72,7 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeDiscussionSubscriptionClassName(
 				_classNameLocalService, _subscriptionLocalService,
 				BlogsEntry.class.getName(),
-				UpgradeDiscussionSubscriptionClassName.DeletionMode.CUSTOM,
-				_retainGroupSubscriptions()));
+				_deleteUnusedBlogsEntrySubscriptions()));
 
 		registry.register(
 			"1.1.3", "2.0.0",
@@ -106,7 +105,7 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 	}
 
 	private UnsafeFunction<String, Boolean, Exception>
-		_retainGroupSubscriptions() {
+		_deleteUnusedBlogsEntrySubscriptions() {
 
 		return className -> {
 			List<Group> groups = _groupLocalService.getGroups(

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -74,7 +74,7 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeDiscussionSubscriptionClassName(
 				_classNameLocalService, _subscriptionLocalService,
 				BlogsEntry.class.getName(),
-				_updateBlogsEntryCommentSubscriptions()));
+				_getUpgradeDiscussionSubscriptionClassNameUnsafeFunction()));
 
 		registry.register(
 			"1.1.3", "2.0.0",
@@ -102,7 +102,7 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 	}
 
 	private UnsafeFunction<String, Boolean, Exception>
-		_updateBlogsEntryCommentSubscriptions() {
+		_getUpgradeDiscussionSubscriptionClassNameUnsafeFunction() {
 
 		return className -> {
 			DynamicQuery groupDynamicQuery = _groupLocalService.dynamicQuery();

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -132,10 +132,9 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 
 				subscription.setClassName(
 					MBDiscussion.class.getName() + StringPool.UNDERLINE +
-					BlogsEntry.class.getName());
+						BlogsEntry.class.getName());
 
-				_subscriptionLocalService.updateSubscription(
-					subscription);
+				_subscriptionLocalService.updateSubscription(subscription);
 			}
 
 			return true;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -87,8 +87,7 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeDiscussionSubscriptionClassName(
 				_classNameLocalService, _subscriptionLocalService,
 				BlogsEntry.class.getName(),
-				UpgradeDiscussionSubscriptionClassName.DeletionMode.CUSTOM,
-				_retainGroupSubscriptions()));
+				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register(
 			"2.0.1", "2.1.0",

--- a/modules/apps/comment/comment-api/build.gradle
+++ b/modules/apps/comment/comment-api/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:subscription:subscription-api")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -21,7 +21,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -83,7 +82,9 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 	}
 
 	public enum DeletionMode {
+
 		ADD_NEW, DELETE_OLD, UPDATE
+
 	}
 
 	@Override
@@ -115,10 +116,10 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		_customFunction = customFunction;
 	}
 
-	private void _addSubscriptions() throws PortalException {
+	private void _addSubscriptions() throws Exception {
 		String newSubscriptionClassName =
 			MBDiscussion.class.getName() + StringPool.UNDERLINE +
-			_oldSubscriptionClassName;
+				_oldSubscriptionClassName;
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_subscriptionLocalService.getActionableDynamicQuery();

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -135,6 +135,7 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 				_subscriptionLocalService.addSubscription(
 					subscription.getUserId(), subscription.getGroupId(),
 					newSubscriptionClassName, subscription.getClassPK()));
+
 		actionableDynamicQuery.performActions();
 	}
 

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -60,14 +60,12 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 	public UpgradeDiscussionSubscriptionClassName(
 		ClassNameLocalService classNameLocalService,
 		SubscriptionLocalService subscriptionLocalService,
-		String oldSubscriptionClassName, DeletionMode deletionMode,
+		String oldSubscriptionClassName,
 		UnsafeFunction<String, Boolean, Exception> customFunction) {
 
-		_classNameLocalService = classNameLocalService;
-		_subscriptionLocalService = subscriptionLocalService;
-		_oldSubscriptionClassName = oldSubscriptionClassName;
-		_deletionMode = deletionMode;
-		_customFunction = customFunction;
+		this(
+			classNameLocalService, subscriptionLocalService,
+			oldSubscriptionClassName, null, customFunction);
 	}
 
 	/**
@@ -90,15 +88,13 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		 */
 		@Deprecated
 		ADD_NEW,
-		CUSTOM, DELETE_OLD, UPDATE
+		DELETE_OLD, UPDATE
 
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if ((_deletionMode == DeletionMode.CUSTOM) &&
-			(_customFunction != null)) {
-
+		if (_customFunction != null) {
 			_customFunction.apply(_oldSubscriptionClassName);
 		}
 		else if (_deletionMode == DeletionMode.DELETE_OLD) {
@@ -107,6 +103,19 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		else {
 			_updateSubscriptions();
 		}
+	}
+
+	private UpgradeDiscussionSubscriptionClassName(
+		ClassNameLocalService classNameLocalService,
+		SubscriptionLocalService subscriptionLocalService,
+		String oldSubscriptionClassName, DeletionMode deletionMode,
+		UnsafeFunction<String, Boolean, Exception> customFunction) {
+
+		_classNameLocalService = classNameLocalService;
+		_subscriptionLocalService = subscriptionLocalService;
+		_oldSubscriptionClassName = oldSubscriptionClassName;
+		_deletionMode = deletionMode;
+		_customFunction = customFunction;
 	}
 
 	private void _deleteSubscriptions() throws Exception {

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -16,6 +16,7 @@ package com.liferay.comment.upgrade;
 
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.message.boards.model.MBDiscussion;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
@@ -51,10 +52,22 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		SubscriptionLocalService subscriptionLocalService,
 		String oldSubscriptionClassName, DeletionMode deletionMode) {
 
+		this(
+			classNameLocalService, subscriptionLocalService,
+			oldSubscriptionClassName, deletionMode, null);
+	}
+
+	public UpgradeDiscussionSubscriptionClassName(
+		ClassNameLocalService classNameLocalService,
+		SubscriptionLocalService subscriptionLocalService,
+		String oldSubscriptionClassName, DeletionMode deletionMode,
+		UnsafeFunction<String, Boolean, Exception> customFunction) {
+
 		_classNameLocalService = classNameLocalService;
 		_subscriptionLocalService = subscriptionLocalService;
 		_oldSubscriptionClassName = oldSubscriptionClassName;
 		_deletionMode = deletionMode;
+		_customFunction = customFunction;
 	}
 
 	/**
@@ -77,13 +90,18 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		 */
 		@Deprecated
 		ADD_NEW,
-		DELETE_OLD, UPDATE
+		CUSTOM, DELETE_OLD, UPDATE
 
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (_deletionMode == DeletionMode.DELETE_OLD) {
+		if ((_deletionMode == DeletionMode.CUSTOM) &&
+			(_customFunction != null)) {
+
+			_customFunction.apply(_oldSubscriptionClassName);
+		}
+		else if (_deletionMode == DeletionMode.DELETE_OLD) {
 			_deleteSubscriptions();
 		}
 		else {
@@ -125,6 +143,7 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 	}
 
 	private final ClassNameLocalService _classNameLocalService;
+	private final UnsafeFunction<String, Boolean, Exception> _customFunction;
 	private final DeletionMode _deletionMode;
 	private final String _oldSubscriptionClassName;
 	private final SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -61,11 +61,11 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		ClassNameLocalService classNameLocalService,
 		SubscriptionLocalService subscriptionLocalService,
 		String oldSubscriptionClassName,
-		UnsafeFunction<String, Boolean, Exception> customFunction) {
+		UnsafeFunction<String, Boolean, Exception> unsafeFunction) {
 
 		this(
 			classNameLocalService, subscriptionLocalService,
-			oldSubscriptionClassName, null, customFunction);
+			oldSubscriptionClassName, null, unsafeFunction);
 	}
 
 	/**
@@ -89,8 +89,8 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (_customFunction != null) {
-			_customFunction.apply(_oldSubscriptionClassName);
+		if (_unsafeFunction != null) {
+			_unsafeFunction.apply(_oldSubscriptionClassName);
 		}
 		else if (_deletionMode == DeletionMode.ADD_NEW) {
 			_addSubscriptions();
@@ -107,13 +107,13 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		ClassNameLocalService classNameLocalService,
 		SubscriptionLocalService subscriptionLocalService,
 		String oldSubscriptionClassName, DeletionMode deletionMode,
-		UnsafeFunction<String, Boolean, Exception> customFunction) {
+		UnsafeFunction<String, Boolean, Exception> unsafeFunction) {
 
 		_classNameLocalService = classNameLocalService;
 		_subscriptionLocalService = subscriptionLocalService;
 		_oldSubscriptionClassName = oldSubscriptionClassName;
 		_deletionMode = deletionMode;
-		_customFunction = customFunction;
+		_unsafeFunction = unsafeFunction;
 	}
 
 	private void _addSubscriptions() throws Exception {
@@ -172,9 +172,9 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 	}
 
 	private final ClassNameLocalService _classNameLocalService;
-	private final UnsafeFunction<String, Boolean, Exception> _customFunction;
 	private final DeletionMode _deletionMode;
 	private final String _oldSubscriptionClassName;
 	private final SubscriptionLocalService _subscriptionLocalService;
+	private final UnsafeFunction<String, Boolean, Exception> _unsafeFunction;
 
 }

--- a/modules/apps/comment/comment-api/src/main/resources/com/liferay/comment/upgrade/packageinfo
+++ b/modules/apps/comment/comment-api/src/main/resources/com/liferay/comment/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/comment/comment-page-comments-web/build.gradle
+++ b/modules/apps/comment/comment-page-comments-web/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:subscription:subscription-api")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/WikiServiceUpgrade.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/WikiServiceUpgrade.java
@@ -64,7 +64,7 @@ public class WikiServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeDiscussionSubscriptionClassName(
 				_classNameLocalService, _subscriptionLocalService,
 				WikiPage.class.getName(),
-				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
+				UpgradeDiscussionSubscriptionClassName.DeletionMode.ADD_NEW));
 
 		registry.register(
 			"1.1.1", "2.0.0",


### PR DESCRIPTION
Hi @achaparro 

I'm using a `PreparedStatement` instead of the previous logic. I tested it, and it has the same functionality.
However, there is an SF error:

```
1: Use existing connection field instead of DataAccess.getConnection: ./src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java 105 (SourceCheck:JavaVerifyUpgradeConnectionCheck)

        at com.liferay.source.formatter.SourceFormatter.format(SourceFormatter.java:445)
        at com.liferay.source.formatter.SourceFormatter.main(SourceFormatter.java:290)

> Task :apps:blogs:blogs-service:formatSource FAILED
```

but since `BlogsServiceUpgrade` is not a subclass of `UpgradeProcess`, it has no `connection` object to inherit.

Best regards,
István
