### PR TITLE
[TS] LPS-130963 | master

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v1_0_4/UpgradeClassNames.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/v1_0_4/UpgradeClassNames.java
@@ -68,6 +68,14 @@ public class UpgradeClassNames extends UpgradeKernelPackage {
 			runSQL(
 				"delete from Subscription where classNameId = " +
 					PortalUtil.getClassNameId(_CLASS_NAME_CAL_EVENT));
+
+			runSQL(
+				"delete from MBDiscussion where classNameId = " +
+					PortalUtil.getClassNameId(_CLASS_NAME_CAL_EVENT));
+
+			runSQL(
+				"delete from MBMessage where classNameId = " +
+					PortalUtil.getClassNameId(_CLASS_NAME_CAL_EVENT));
 		}
 		catch (Exception exception) {
 			throw new UpgradeException(exception);


### PR DESCRIPTION
Hi @achaparro 

Send to you for review.

### Description
Upgrading from `6.`1 to `7.3` has arisen spurious records related to calendar events two message boards tables: MBMessages and MBDiscussions.
These records cause indexing errors because of the _className_ `com.liferay.portlet.calendar.model.CalEvent` was removed previous to `7.3`.

### Steps to reproduce

1. In a `6.1` portal add a Calendar portlet to a page.
2. Under _'Liferay's Calendar_' combo, click on down arrow of 'Liferay' calendar option. Choose '_Calendar Settings_' option. Then click on '_Enable Comments_' check. Save.
3. Create a Calendar Event.
4. Open the created Calendar Event (just click on its link, do not edit it) and add a comment.
5. Execute the following query and save the _classNameId_ returned that will be used for future queries:
 ```
select classNameId from ClassName_ where value = 'com.liferay.portlet.calendar.model.CalEvent'
```
6. Ensure, with the following queries, that there are records in the two tables:    
```
select * from mbmessage where classnameid = <classNameId>;    

select * from mbdiscussion where classnameid = <classNameId>;    

For the <classNameId> use the one returned in step 5.
```
7. Upgrade to `6.2`
8. Ensure, with the following queries, that there are records in the two tables:    
```
select * from mbmessage where classnameid = <classNameId>;    

select * from mbdiscussion where classnameid = <classNameId>;    

For the <classNameId> use the one returned in step 5.
```
9. Upgrade to `master`.
10. Check if there are still old CalEvent _classNameId_ records in the two tables:
 ```
select * from mbmessage where classnameid = <classNameId>

select * from mbdiscussion where classnameid = <classNameId>

For the <classNameId> use the one returned in step 5.
```

### Solution proposed
Adding delete sentences into upgrade step related to UpgradeClassNames for both tables.

### References
https://issues.liferay.com/browse/LPS-130963

