### PR TITLE
LPS-131851 (Part 2)

### DIFF
--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java
@@ -18,8 +18,8 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.style.book.internal.upgrade.v1_1_0.StyleBookEntryUpgradeProcess;
-import com.liferay.style.book.internal.upgrade.v1_3_0.StyleBookEntryVersionUpgradeProcess;
-import com.liferay.style.book.internal.upgrade.v1_3_0.util.UpgradeMVCCVersion;
+import com.liferay.style.book.internal.upgrade.v1_2_0.StyleBookEntryVersionUpgradeProcess;
+import com.liferay.style.book.internal.upgrade.v1_2_0.util.UpgradeMVCCVersion;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -39,11 +39,11 @@ public class StyleBookServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register("1.0.0", "1.1.0", new StyleBookEntryUpgradeProcess());
 
 		registry.register(
-			"1.1.0", "1.2.0", new UpgradeCTModel("StyleBookEntry"));
+			"1.1.0", "1.2.0", new UpgradeMVCCVersion(),
+			new StyleBookEntryVersionUpgradeProcess());
 
 		registry.register(
-			"1.2.0", "1.3.0", new UpgradeMVCCVersion(),
-			new StyleBookEntryVersionUpgradeProcess());
+			"1.2.0", "1.3.0", new UpgradeCTModel("StyleBookEntry"));
 
 		registry.register(
 			"1.3.0", "1.4.0", new UpgradeCTModel("StyleBookEntryVersion"));

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/StyleBookEntryVersionUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/StyleBookEntryVersionUpgradeProcess.java
@@ -12,13 +12,13 @@
  * details.
  */
 
-package com.liferay.style.book.internal.upgrade.v1_3_0;
+package com.liferay.style.book.internal.upgrade.v1_2_0;
 
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
-import com.liferay.style.book.internal.upgrade.v1_3_0.util.StyleBookEntryVersionTable;
+import com.liferay.style.book.internal.upgrade.v1_2_0.util.StyleBookEntryVersionTable;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/StyleBookEntryVersionTable.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/StyleBookEntryVersionTable.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.style.book.internal.upgrade.v1_3_0.util;
+package com.liferay.style.book.internal.upgrade.v1_2_0.util;
 
 import java.sql.Types;
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/StyleBookEntryVersionTable.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/StyleBookEntryVersionTable.java
@@ -28,7 +28,6 @@ public class StyleBookEntryVersionTable {
 	public static final String TABLE_NAME = "StyleBookEntryVersion";
 
 	public static final Object[][] TABLE_COLUMNS = {
-		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
 		{"styleBookEntryVersionId", Types.BIGINT}, {"version", Types.INTEGER},
 		{"uuid_", Types.VARCHAR}, {"styleBookEntryId", Types.BIGINT},
 		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
@@ -44,10 +43,6 @@ public class StyleBookEntryVersionTable {
 new HashMap<String, Integer>();
 
 static {
-TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
-
-TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
-
 TABLE_COLUMNS_MAP.put("styleBookEntryVersionId", Types.BIGINT);
 
 TABLE_COLUMNS_MAP.put("version", Types.INTEGER);
@@ -80,28 +75,20 @@ TABLE_COLUMNS_MAP.put("styleBookEntryKey", Types.VARCHAR);
 
 }
 	public static final String TABLE_SQL_CREATE =
-"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,primary key (styleBookEntryVersionId, ctCollectionId))";
+"create table StyleBookEntryVersion (styleBookEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null)";
 
 	public static final String TABLE_SQL_DROP =
 "drop table StyleBookEntryVersion";
 
 	public static final String[] TABLE_SQL_ADD_INDEXES = {
-		"create index IX_B34844C2 on StyleBookEntryVersion (groupId, ctCollectionId)",
-		"create index IX_E88B42E3 on StyleBookEntryVersion (groupId, defaultStyleBookEntry, ctCollectionId)",
-		"create index IX_4DF1581 on StyleBookEntryVersion (groupId, defaultStyleBookEntry, version, ctCollectionId)",
-		"create index IX_3BC5DB81 on StyleBookEntryVersion (groupId, name[$COLUMN_LENGTH:75$], ctCollectionId)",
-		"create index IX_13634EA3 on StyleBookEntryVersion (groupId, name[$COLUMN_LENGTH:75$], version, ctCollectionId)",
-		"create index IX_68B20A51 on StyleBookEntryVersion (groupId, styleBookEntryKey[$COLUMN_LENGTH:75$], ctCollectionId)",
-		"create unique index IX_5DF6C9D3 on StyleBookEntryVersion (groupId, styleBookEntryKey[$COLUMN_LENGTH:75$], version, ctCollectionId)",
-		"create index IX_142CBE82 on StyleBookEntryVersion (groupId, version, ctCollectionId)",
-		"create index IX_39DEBFAB on StyleBookEntryVersion (styleBookEntryId, ctCollectionId)",
-		"create unique index IX_ED1779B9 on StyleBookEntryVersion (styleBookEntryId, version, ctCollectionId)",
-		"create index IX_81A333D8 on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId)",
-		"create index IX_59FE682C on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], companyId, version, ctCollectionId)",
-		"create index IX_911BCC4C on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], ctCollectionId)",
-		"create index IX_A72F8CDA on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId)",
-		"create unique index IX_22D9116A on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], groupId, version, ctCollectionId)",
-		"create index IX_7DF81238 on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], version, ctCollectionId)"
+		"create index IX_3CA4E523 on StyleBookEntryVersion (groupId, defaultStyleBookEntry, version)",
+		"create index IX_7B3A245 on StyleBookEntryVersion (groupId, name[$COLUMN_LENGTH:75$], version)",
+		"create unique index IX_5F837D75 on StyleBookEntryVersion (groupId, styleBookEntryKey[$COLUMN_LENGTH:75$], version)",
+		"create index IX_9A3EB024 on StyleBookEntryVersion (groupId, version)",
+		"create unique index IX_21DCB95B on StyleBookEntryVersion (styleBookEntryId, version)",
+		"create index IX_D15CEDCE on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], companyId, version)",
+		"create unique index IX_5D7DD30C on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], groupId, version)",
+		"create index IX_D0242FDA on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$], version)"
 	};
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/UpgradeMVCCVersion.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/UpgradeMVCCVersion.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.style.book.internal.upgrade.v1_3_0.util;
+package com.liferay.style.book.internal.upgrade.v1_2_0.util;
 
 /**
  * @author Víctor Galán


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-131851>

**Notes:**
Previous pull request: <https://github.com/achaparro/liferay-portal/pull/891>

As requested, using the trick you outlined involving `gw buildUpgradeTable`, I regenerated the upgrade table to remove the `ctCollectionId` field along with the `mvccVersion` field from the `StyleBookEntryVersion` upgrade table. Let me know if I made a mistake with regenerating the table or if I missed something.

cc: @SamZiemer