### PR TITLE
[TS] LPS-132627 Use the IS NULL operator to get all the records that have a NULL primKeyId

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -172,7 +172,7 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			StringBundler.concat(
 				"update ResourcePermission set primKeyId = CAST_LONG(primKey",
 				") where name = '", name,
-				"' and (primKey not like '%_LAYOUT_%' and primKeyId != 0)"));
+				"' and (primKey not like '%_LAYOUT_%' and primKeyId IS NULL)"));
 	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132627

Regression caused by [LPS-118989](https://issues.liferay.com/browse/LPS-118989), we should use `IS NULL` instead of `!= 0`