### PR TITLE
[TS] LPS-132719 Populate primKeyId and viewActionId columns

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseAdminPortletsUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseAdminPortletsUpgradeProcess.java
@@ -35,9 +35,19 @@ public abstract class BaseAdminPortletsUpgradeProcess extends UpgradeProcess {
 		throws Exception {
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"insert into ResourcePermission (resourcePermissionId, " +
-					"companyId, name, scope, primKey, roleId, actionIds) " +
-						"values (?, ?, ?, ?, ?, ?, ?)")) {
+				StringBundler.concat(
+					"insert into ResourcePermission (resourcePermissionId, ",
+					"companyId, name, scope, primKey, roleId, actionIds, ",
+					"primKeyId, viewActionId) values (?, ?, ?, ?, ?, ?, ?, ?, ",
+					"?)"))) {
+
+			long primKeyId = GetterUtil.getLong(primKey);
+
+			boolean viewActionId = false;
+
+			if ((actionIds % 2) == 1) {
+				viewActionId = true;
+			}
 
 			preparedStatement.setLong(1, resourcePermissionId);
 			preparedStatement.setLong(2, companyId);
@@ -46,6 +56,8 @@ public abstract class BaseAdminPortletsUpgradeProcess extends UpgradeProcess {
 			preparedStatement.setString(5, primKey);
 			preparedStatement.setLong(6, roleId);
 			preparedStatement.setLong(7, actionIds);
+			preparedStatement.setLong(8, primKeyId);
+			preparedStatement.setBoolean(9, viewActionId);
 
 			preparedStatement.executeUpdate();
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradeAdminPortlets.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradeAdminPortlets.java
@@ -38,9 +38,19 @@ public abstract class BaseUpgradeAdminPortlets extends UpgradeProcess {
 		throws Exception {
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"insert into ResourcePermission (resourcePermissionId, " +
-					"companyId, name, scope, primKey, roleId, actionIds) " +
-						"values (?, ?, ?, ?, ?, ?, ?)")) {
+				StringBundler.concat(
+					"insert into ResourcePermission (resourcePermissionId, ",
+					"companyId, name, scope, primKey, roleId, actionIds, ",
+					"primKeyId, viewActionId) values (?, ?, ?, ?, ?, ?, ?, ?, ",
+					"?)"))) {
+
+			long primKeyId = GetterUtil.getLong(primKey);
+
+			boolean viewActionId = false;
+
+			if ((actionIds % 2) == 1) {
+				viewActionId = true;
+			}
 
 			preparedStatement.setLong(1, resourcePermissionId);
 			preparedStatement.setLong(2, companyId);
@@ -49,6 +59,8 @@ public abstract class BaseUpgradeAdminPortlets extends UpgradeProcess {
 			preparedStatement.setString(5, primKey);
 			preparedStatement.setLong(6, roleId);
 			preparedStatement.setLong(7, actionIds);
+			preparedStatement.setLong(8, primKeyId);
+			preparedStatement.setBoolean(9, viewActionId);
 
 			preparedStatement.executeUpdate();
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132719

The ResourcePermission table is not populated with a primKeyId and a viewActionId in the ResourcePermission  records created by com.liferay.portal.kernel.upgrade.BaseAdminPortletsUpgradeProcess subclasses. (BaseUpgradeAdminPortlets in the old 7.3.x branch)

The primKeyId and viewActionId are populated in the com.liferay.portal.upgrade.v7_0_0.UpgradeResourcePermission class, but BaseUpgradeAdminPortlets subclasses are upgrade modules that are executed after that class:
* modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/upgrade/v1_0_0/UpgradeAdminPortlets.java
* modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_0_0/UpgradeAdminPortlets.java

To avoid this issue, we have to populate these columns in the BaseAdminPortletsUpgradeProcess.addResourcePermission method.