### PR TITLE
LPS-133602

### DIFF
--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -819,7 +819,9 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	)
 	private RepositoryFactory _repositoryFactory;
 
-	@Reference
+	@Reference(
+		target = "(release.bundle.symbolic.name=com.liferay.document.library.repository.portlet.repository.impl)"
+	)
 	private RepositoryLocalService _repositoryLocalService;
 
 	@Reference


### PR DESCRIPTION
The Journal Service upgrade calls [this code](https://github.com/liferay/liferay-portal/blob/3b99c7e1281a3d35b6237481963ccc832a7a3334/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java#L281) 
in the `com.liferay.document.library.repository.portlet.file.repository.impl` module to add a repository. That code attempts to look up the [PortletRepository](https://github.com/liferay/liferay-portal/blob/3b99c7e1281a3d35b6237481963ccc832a7a3334/portal-impl/src/com/liferay/portal/repository/portletrepository/PortletRepository.java) class.

A different module, the `com.liferay.document.library.repository.portlet.repository.impl` module, holds the holds [the class](https://github.com/liferay/liferay-portal/blob/3b99c7e1281a3d35b6237481963ccc832a7a3334/modules/apps/document-library/document-library-repository-portlet-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/repository/internal/PortletRepositoryDefiner.java) responsible for registering the PortletRepository class.

There is no guarantee that the `com.liferay.document.library.repository.portlet.repository.impl` module will have been deployed by the time the Journal Service upgrade runs. We should add a dependency from the `com.liferay.document.library.repository.portlet.file.repository.impl` module onto the `com.liferay.document.library.repository.portlet.repository.impl` module to ensure that we don't encounter an UndeployedExternalRepositoryException from trying to fetch the PortletRepository class before it has been registered.