### PR TITLE
LPS-134268 Add missing case for KB articles

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
@@ -245,6 +245,9 @@ public class UpgradeSubscription extends UpgradeProcess {
 			"com.liferay.calendar.model.CalendarBooking",
 			"CalendarBooking,groupId,calendarBookingId"
 		).put(
+			"com.liferay.knowledgebase.model.KBArticle",
+			"KBArticle,groupId,kbArticleId"
+		).put(
 			"com.liferay.message.boards.kernel.model.MBCategory",
 			"MBCategory,groupId,categoryId"
 		).put(


### PR DESCRIPTION
**Tickets:**
<https://issues.liferay.com/browse/LPS-134268>

**Notes from @kevhlee:**

> This issue is nearly identical to [LPS-128867](https://issues.liferay.com/browse/LPS-128867) except that it deals with KB article subscriptions instead of Asset Publisher subscriptions. In this case, the solution is to simply include KB articles to `_getGroupIdSQLPartsMap` to allow retrieval of the `groupId`. One small thing to note is that I'm referencing the model by the string `"com.liferay.knowledgebase.model.KBArticle"` and not `"com.liferay.knowledge.base.model.KBArticle"` as the `className` is not updated yet by the time the upgrade hits `v7_0_0.UpgradeSubscription`.
> 
> Let me know if you have any questions/thoughts.