### PR TITLE
Lps 128860

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReportImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReportImpl.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.internal.report;
+
+import com.liferay.portal.kernel.upgrade.UpgradeReport;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Sam Ziemer
+ */
+@Component(
+	immediate = true, service = {UpgradeReport.class, UpgradeReportImpl.class}
+)
+public class UpgradeReportImpl implements UpgradeReport {
+
+	public void addError(String loggerName, String message) {
+		List<String> errors = _errors.computeIfAbsent(
+			loggerName, key -> new ArrayList<>());
+
+		errors.add(message);
+	}
+
+	public void addEvent(String loggerName, String message) {
+		List<String> events = _events.computeIfAbsent(
+			loggerName, key -> new ArrayList<>());
+
+		events.add(message);
+	}
+
+	public void addWarning(String loggerName, String message) {
+		List<String> warnings = _warnings.computeIfAbsent(
+			loggerName, key -> new ArrayList<>());
+
+		warnings.add(message);
+	}
+
+	@Override
+	public void generateReport() {
+	}
+
+	private static final Map<String, ArrayList<String>> _errors =
+		new HashMap<>();
+	private static final Map<String, ArrayList<String>> _events =
+		new HashMap<>();
+	private static final Map<String, ArrayList<String>> _warnings =
+		new HashMap<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -56,6 +56,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import org.apache.commons.lang.time.StopWatch;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 
 import org.springframework.context.ApplicationContext;
 
@@ -125,6 +127,12 @@ public class DBUpgrader {
 			try (SafeCloseable safeCloseable =
 					ProxyModeThreadLocal.setWithSafeCloseable(false)) {
 
+				UpgradeLogAppender appender = new UpgradeLogAppender();
+
+				appender.start();
+
+				_rootLogger.addAppender(appender);
+
 				upgrade();
 			}
 
@@ -142,6 +150,9 @@ public class DBUpgrader {
 			exception.printStackTrace();
 
 			System.exit(1);
+		}
+		finally {
+			UpgradeLogAppender.close();
 		}
 	}
 
@@ -376,5 +387,8 @@ public class DBUpgrader {
 	private static final Version _VERSION_7010 = new Version(0, 0, 6);
 
 	private static final Log _log = LogFactoryUtil.getLog(DBUpgrader.class);
+
+	private static final Logger _rootLogger =
+		(Logger)LogManager.getRootLogger();
 
 }

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -127,11 +127,13 @@ public class DBUpgrader {
 			try (SafeCloseable safeCloseable =
 					ProxyModeThreadLocal.setWithSafeCloseable(false)) {
 
-				UpgradeLogAppender appender = new UpgradeLogAppender();
+				if (PropsValues.UPGRADE_REPORT_ENABLED) {
+					UpgradeLogAppender appender = new UpgradeLogAppender();
 
-				appender.start();
+					appender.start();
 
-				_rootLogger.addAppender(appender);
+					_rootLogger.addAppender(appender);
+				}
 
 				upgrade();
 			}
@@ -152,7 +154,9 @@ public class DBUpgrader {
 			System.exit(1);
 		}
 		finally {
-			UpgradeLogAppender.close();
+			if (PropsValues.UPGRADE_REPORT_ENABLED) {
+				UpgradeLogAppender.close();
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/tools/UpgradeLogAppender.java
+++ b/portal-impl/src/com/liferay/portal/tools/UpgradeLogAppender.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.ErrorHandler;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+
+/**
+ * @author Sam Ziemer
+ */
+public class UpgradeLogAppender implements Appender {
+
+	public static void close() {
+	}
+
+	@Override
+	public void append(LogEvent event) {
+		if (event.getLevel() == Level.ERROR) {
+			_errorLogEvents.add(event);
+		}
+		else if (event.getLevel() == Level.WARN) {
+			_warningLogEvents.add(event);
+		}
+		else if (event.getLevel() == Level.INFO) {
+			String loggerName = event.getLoggerName();
+
+			if (loggerName.equals(UpgradeProcess.class.getName())) {
+				_reportEvents.add(event);
+			}
+		}
+	}
+
+	public List<LogEvent> getErrorLogEvents() {
+		return _errorLogEvents;
+	}
+
+	public List<LogEvent> getEvents() {
+		return _reportEvents;
+	}
+
+	@Override
+	public ErrorHandler getHandler() {
+		return null;
+	}
+
+	@Override
+	public Layout<? extends Serializable> getLayout() {
+		return null;
+	}
+
+	@Override
+	public String getName() {
+		return "UpgradeLogAppender";
+	}
+
+	@Override
+	public State getState() {
+		return null;
+	}
+
+	public List<LogEvent> getWarningLogEvents() {
+		return _warningLogEvents;
+	}
+
+	@Override
+	public boolean ignoreExceptions() {
+		return false;
+	}
+
+	@Override
+	public void initialize() {
+	}
+
+	@Override
+	public boolean isStarted() {
+		return _started;
+	}
+
+	@Override
+	public boolean isStopped() {
+		return !_started;
+	}
+
+	@Override
+	public void setHandler(ErrorHandler handler) {
+	}
+
+	@Override
+	public void start() {
+		_started = true;
+	}
+
+	@Override
+	public void stop() {
+		_started = false;
+	}
+
+	private final List<LogEvent> _errorLogEvents = new ArrayList<>();
+	private final List<LogEvent> _reportEvents = new ArrayList<>();
+	private boolean _started;
+	private final List<LogEvent> _warningLogEvents = new ArrayList<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -3007,6 +3007,9 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_DATABASE_TRANSACTIONS_DISABLED));
 
+	public static final boolean UPGRADE_REPORT_ENABLED = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.UPGRADE_REPORT_ENABLED));
+
 	public static boolean USER_GROUPS_NAME_ALLOW_NUMERIC =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.USER_GROUPS_NAME_ALLOW_NUMERIC));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -137,6 +137,14 @@
     #
     upgrade.database.transactions.disabled=true
 
+    #
+    # Set this to true to generate a report of errors, warnings, and events
+    # after the upgrade completes.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_REPORT_PERIOD_ENABLED
+    #
+    upgrade.report.enabled=false
+
 ##
 ## Verify
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeReport.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeReport.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.upgrade;
+
+/**
+ * @author Sam Ziemer
+ */
+public interface UpgradeReport {
+
+	public void addError(String loggerName, String message);
+
+	public void addEvent(String loggerName, String message);
+
+	public void addWarning(String loggerName, String message);
+
+	public void generateReport();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3355,6 +3355,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_DATABASE_TRANSACTIONS_DISABLED =
 		"upgrade.database.transactions.disabled";
 
+	public static final String UPGRADE_REPORT_ENABLED =
+		"upgrade.report.enabled";
+
 	public static final String USER_GROUPS_NAME_ALLOW_NUMERIC =
 		"user.groups.name.allow.numeric";
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-128860

Hi @achaparro,

This is not meant to be a final pull request, but I wanted to get something to you to review before I start work on Monday.

The log appender calls an UpgradeReport service to store all messages. I still need to do some additional formatting on how we store the messages, but I think that will be easier to determine once I start designing the report. I did not add any property or flags or anything to determine when the report is generated at this time because those are relatively simple steps that can be done easily later on.

Please let me know if you see something that looks incorrect, or something I should do better here. Also, I think it would be helpful for me to test with various databases that have difference kinds of failures to ensure I am capturing them properly. Next week I will start making databases that have failures intentionally, but I wanted to check if you know of any backups that have a lot of errors or warnings I could test with.

Lastly, I know Brian Chan mentioned he did not like the term report when we were planning on using a log wrapper, but thats the term I used for now as I thought with us keeping it located within upgrade packages that it may be ok. If you think otherwise, let me know and we can decide on a better name.