### PR TITLE
LPS-107816

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.api
-Bundle-Version: 7.1.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo,\
 	com.liferay.portal.workflow.kaleo.constants,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionModel.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionModel.java
@@ -436,15 +436,14 @@ public interface KaleoDefinitionVersionModel
 	 *
 	 * @return the version of this kaleo definition version
 	 */
-	@AutoEscape
-	public String getVersion();
+	public int getVersion();
 
 	/**
 	 * Sets the version of this kaleo definition version.
 	 *
 	 * @param version the version of this kaleo definition version
 	 */
-	public void setVersion(String version);
+	public void setVersion(int version);
 
 	/**
 	 * Returns the start kaleo node ID of this kaleo definition version.

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionSoap.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionSoap.java
@@ -245,11 +245,11 @@ public class KaleoDefinitionVersionSoap implements Serializable {
 		_content = content;
 	}
 
-	public String getVersion() {
+	public int getVersion() {
 		return _version;
 	}
 
-	public void setVersion(String version) {
+	public void setVersion(int version) {
 		_version = version;
 	}
 
@@ -285,7 +285,7 @@ public class KaleoDefinitionVersionSoap implements Serializable {
 	private String _title;
 	private String _description;
 	private String _content;
-	private String _version;
+	private int _version;
 	private long _startKaleoNodeId;
 	private int _status;
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionTable.java
@@ -80,9 +80,9 @@ public class KaleoDefinitionVersionTable
 			"description", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<KaleoDefinitionVersionTable, Clob> content =
 		createColumn("content", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
-	public final Column<KaleoDefinitionVersionTable, String> version =
+	public final Column<KaleoDefinitionVersionTable, Integer> version =
 		createColumn(
-			"version", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+			"version", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 	public final Column<KaleoDefinitionVersionTable, Long> startKaleoNodeId =
 		createColumn(
 			"startKaleoNodeId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionWrapper.java
@@ -167,7 +167,7 @@ public class KaleoDefinitionVersionWrapper
 			setContent(content);
 		}
 
-		String version = (String)attributes.get("version");
+		Integer version = (Integer)attributes.get("version");
 
 		if (version != null) {
 			setVersion(version);
@@ -501,7 +501,7 @@ public class KaleoDefinitionVersionWrapper
 	 * @return the version of this kaleo definition version
 	 */
 	@Override
-	public String getVersion() {
+	public int getVersion() {
 		return model.getVersion();
 	}
 
@@ -884,7 +884,7 @@ public class KaleoDefinitionVersionWrapper
 	 * @param version the version of this kaleo definition version
 	 */
 	@Override
-	public void setVersion(String version) {
+	public void setVersion(int version) {
 		model.setVersion(version);
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionVersionPersistence.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionVersionPersistence.java
@@ -350,7 +350,7 @@ public interface KaleoDefinitionVersionPersistence
 	 * @throws NoSuchDefinitionVersionException if a matching kaleo definition version could not be found
 	 */
 	public KaleoDefinitionVersion findByC_N_V(
-			long companyId, String name, String version)
+			long companyId, String name, int version)
 		throws NoSuchDefinitionVersionException;
 
 	/**
@@ -362,7 +362,7 @@ public interface KaleoDefinitionVersionPersistence
 	 * @return the matching kaleo definition version, or <code>null</code> if a matching kaleo definition version could not be found
 	 */
 	public KaleoDefinitionVersion fetchByC_N_V(
-		long companyId, String name, String version);
+		long companyId, String name, int version);
 
 	/**
 	 * Returns the kaleo definition version where companyId = &#63; and name = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
@@ -374,7 +374,7 @@ public interface KaleoDefinitionVersionPersistence
 	 * @return the matching kaleo definition version, or <code>null</code> if a matching kaleo definition version could not be found
 	 */
 	public KaleoDefinitionVersion fetchByC_N_V(
-		long companyId, String name, String version, boolean useFinderCache);
+		long companyId, String name, int version, boolean useFinderCache);
 
 	/**
 	 * Removes the kaleo definition version where companyId = &#63; and name = &#63; and version = &#63; from the database.
@@ -385,7 +385,7 @@ public interface KaleoDefinitionVersionPersistence
 	 * @return the kaleo definition version that was removed
 	 */
 	public KaleoDefinitionVersion removeByC_N_V(
-			long companyId, String name, String version)
+			long companyId, String name, int version)
 		throws NoSuchDefinitionVersionException;
 
 	/**
@@ -396,7 +396,7 @@ public interface KaleoDefinitionVersionPersistence
 	 * @param version the version
 	 * @return the number of matching kaleo definition versions
 	 */
-	public int countByC_N_V(long companyId, String name, String version);
+	public int countByC_N_V(long companyId, String name, int version);
 
 	/**
 	 * Caches the kaleo definition version in the entity cache if it is enabled.

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionVersionUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionVersionUtil.java
@@ -503,7 +503,7 @@ public class KaleoDefinitionVersionUtil {
 	 * @throws NoSuchDefinitionVersionException if a matching kaleo definition version could not be found
 	 */
 	public static KaleoDefinitionVersion findByC_N_V(
-			long companyId, String name, String version)
+			long companyId, String name, int version)
 		throws com.liferay.portal.workflow.kaleo.exception.
 			NoSuchDefinitionVersionException {
 
@@ -519,7 +519,7 @@ public class KaleoDefinitionVersionUtil {
 	 * @return the matching kaleo definition version, or <code>null</code> if a matching kaleo definition version could not be found
 	 */
 	public static KaleoDefinitionVersion fetchByC_N_V(
-		long companyId, String name, String version) {
+		long companyId, String name, int version) {
 
 		return getPersistence().fetchByC_N_V(companyId, name, version);
 	}
@@ -534,7 +534,7 @@ public class KaleoDefinitionVersionUtil {
 	 * @return the matching kaleo definition version, or <code>null</code> if a matching kaleo definition version could not be found
 	 */
 	public static KaleoDefinitionVersion fetchByC_N_V(
-		long companyId, String name, String version, boolean useFinderCache) {
+		long companyId, String name, int version, boolean useFinderCache) {
 
 		return getPersistence().fetchByC_N_V(
 			companyId, name, version, useFinderCache);
@@ -549,7 +549,7 @@ public class KaleoDefinitionVersionUtil {
 	 * @return the kaleo definition version that was removed
 	 */
 	public static KaleoDefinitionVersion removeByC_N_V(
-			long companyId, String name, String version)
+			long companyId, String name, int version)
 		throws com.liferay.portal.workflow.kaleo.exception.
 			NoSuchDefinitionVersionException {
 
@@ -564,9 +564,7 @@ public class KaleoDefinitionVersionUtil {
 	 * @param version the version
 	 * @return the number of matching kaleo definition versions
 	 */
-	public static int countByC_N_V(
-		long companyId, String name, String version) {
-
+	public static int countByC_N_V(long companyId, String name, int version) {
 		return getPersistence().countByC_N_V(companyId, name, version);
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/util/comparator/KaleoDefinitionVersionVersionComparator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/util/comparator/KaleoDefinitionVersionVersionComparator.java
@@ -14,9 +14,7 @@
 
 package com.liferay.portal.workflow.kaleo.util.comparator;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 
 /**
@@ -40,31 +38,13 @@ public class KaleoDefinitionVersionVersionComparator
 
 		int value = 0;
 
-		String version1 = kaleoDefinitionVersion1.getVersion();
-		String version2 = kaleoDefinitionVersion2.getVersion();
+		int version1 = kaleoDefinitionVersion1.getVersion();
+		int version2 = kaleoDefinitionVersion2.getVersion();
 
-		int[] versionParts1 = StringUtil.split(version1, StringPool.PERIOD, 0);
-		int[] versionParts2 = StringUtil.split(version2, StringPool.PERIOD, 0);
-
-		if ((versionParts1.length != 2) && (versionParts2.length != 2)) {
-			value = 0;
-		}
-		else if (versionParts1.length != 2) {
-			value = -1;
-		}
-		else if (versionParts2.length != 2) {
+		if (version1 > version2) {
 			value = 1;
 		}
-		else if (versionParts1[0] > versionParts2[0]) {
-			value = 1;
-		}
-		else if (versionParts1[0] < versionParts2[0]) {
-			value = -1;
-		}
-		else if (versionParts1[1] > versionParts2[1]) {
-			value = 1;
-		}
-		else if (versionParts1[1] < versionParts2[1]) {
+		else if (version1 < version2) {
 			value = -1;
 		}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/model/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 4.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/persistence/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.7.0
+version 5.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/export/builder/DefaultDefinitionBuilder.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/export/builder/DefaultDefinitionBuilder.java
@@ -16,9 +16,7 @@ package com.liferay.portal.workflow.kaleo.definition.internal.export.builder;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.workflow.kaleo.definition.Definition;
 import com.liferay.portal.workflow.kaleo.definition.Node;
 import com.liferay.portal.workflow.kaleo.definition.Transition;
@@ -75,7 +73,7 @@ public class DefaultDefinitionBuilder implements DefinitionBuilder {
 			kaleoDefinitionVersion.getName(),
 			kaleoDefinitionVersion.getDescription(),
 			kaleoDefinitionVersion.getContent(),
-			_getVersion(kaleoDefinitionVersion.getVersion()));
+			kaleoDefinitionVersion.getVersion());
 
 		List<KaleoNode> kaleoNodes =
 			_kaleoNodeLocalService.getKaleoDefinitionVersionKaleoNodes(
@@ -114,12 +112,6 @@ public class DefaultDefinitionBuilder implements DefinitionBuilder {
 		}
 
 		return definition;
-	}
-
-	private int _getVersion(String version) {
-		int[] versionParts = StringUtil.split(version, StringPool.PERIOD, 0);
-
-		return versionParts[0];
 	}
 
 	@Reference

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/export/builder/DefaultDefinitionBuilder.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/export/builder/DefaultDefinitionBuilder.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.workflow.kaleo.definition.internal.export.builder;
 
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.workflow.kaleo.definition.Definition;
 import com.liferay.portal.workflow.kaleo.definition.Node;
@@ -51,8 +49,7 @@ public class DefaultDefinitionBuilder implements DefinitionBuilder {
 		return doBuildDefinition(
 			_kaleoDefinitionVersionLocalService.getKaleoDefinitionVersion(
 				kaleoDefinition.getCompanyId(), kaleoDefinition.getName(),
-				StringBundler.concat(
-					kaleoDefinition.getVersion(), CharPool.PERIOD, 0)));
+				String.valueOf(kaleoDefinition.getVersion())));
 	}
 
 	@Override
@@ -61,8 +58,7 @@ public class DefaultDefinitionBuilder implements DefinitionBuilder {
 
 		return doBuildDefinition(
 			_kaleoDefinitionVersionLocalService.getKaleoDefinitionVersion(
-				companyId, name,
-				StringBundler.concat(version, CharPool.PERIOD, 0)));
+				companyId, name, String.valueOf(version)));
 	}
 
 	protected Definition doBuildDefinition(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultWorkflowEngineImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultWorkflowEngineImpl.java
@@ -639,8 +639,8 @@ public class DefaultWorkflowEngineImpl
 					kaleoDefinition.getKaleoDefinitionId(),
 					kaleoDefinitionVersion.getKaleoDefinitionVersionId(),
 					kaleoDefinitionVersion.getName(),
-					getVersion(kaleoDefinitionVersion.getVersion()),
-					workflowContext, serviceContext);
+					kaleoDefinitionVersion.getVersion(), workflowContext,
+					serviceContext);
 
 			KaleoInstanceToken rootKaleoInstanceToken =
 				kaleoInstance.getRootKaleoInstanceToken(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/KaleoWorkflowModelConverterImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/KaleoWorkflowModelConverterImpl.java
@@ -156,7 +156,7 @@ public class KaleoWorkflowModelConverterImpl
 				content = _definitionExporter.export(
 					kaleoDefinitionVersion.getCompanyId(),
 					kaleoDefinitionVersion.getName(),
-					getVersion(kaleoDefinitionVersion.getVersion()));
+					kaleoDefinitionVersion.getVersion());
 
 				kaleoDefinitionVersion.setContent(content);
 
@@ -183,7 +183,7 @@ public class KaleoWorkflowModelConverterImpl
 		defaultWorkflowDefinition.setTitle(kaleoDefinitionVersion.getTitle());
 		defaultWorkflowDefinition.setUserId(kaleoDefinitionVersion.getUserId());
 		defaultWorkflowDefinition.setVersion(
-			getVersion(kaleoDefinitionVersion.getVersion()));
+			kaleoDefinitionVersion.getVersion());
 
 		return defaultWorkflowDefinition;
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
@@ -437,18 +437,6 @@ public class WorkflowDefinitionManagerImpl
 			new UnsyncByteArrayInputStream(bytes));
 	}
 
-	protected String getNextVersion(String version) {
-		try {
-			return String.valueOf(Integer.parseInt(version) + 1);
-		}
-		catch (NumberFormatException numberFormatException) {
-			int[] versionParts = StringUtil.split(
-				version, StringPool.PERIOD, 0);
-
-			return String.valueOf(++versionParts[0]);
-		}
-	}
-
 	protected String getVersion(int version) {
 		return String.valueOf(version);
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
@@ -15,14 +15,12 @@
 package com.liferay.portal.workflow.kaleo.runtime.integration.internal;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.uuid.PortalUUID;
 import com.liferay.portal.kernel.workflow.RequiredWorkflowDefinitionException;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
@@ -438,13 +438,19 @@ public class WorkflowDefinitionManagerImpl
 	}
 
 	protected String getNextVersion(String version) {
-		int[] versionParts = StringUtil.split(version, StringPool.PERIOD, 0);
+		try {
+			return String.valueOf(Integer.parseInt(version) + 1);
+		}
+		catch (NumberFormatException numberFormatException) {
+			int[] versionParts = StringUtil.split(
+				version, StringPool.PERIOD, 0);
 
-		return String.valueOf(++versionParts[0]);
+			return String.valueOf(++versionParts[0]);
+		}
 	}
 
 	protected String getVersion(int version) {
-		return version + StringPool.PERIOD + 0;
+		return String.valueOf(version);
 	}
 
 	protected List<WorkflowDefinition> toWorkflowDefinitions(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	!org.apache.commons.httpclient.*,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.1.1
+Liferay-Require-SchemaVersion: 4.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/service.xml
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/service.xml
@@ -211,7 +211,7 @@
 		<column localized="true" name="title" type="String" />
 		<column name="description" type="String" />
 		<column name="content" type="String" />
-		<column name="version" type="String" />
+		<column name="version" type="int" />
 		<column name="startKaleoNodeId" type="long" />
 		<column name="status" type="int" />
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/KaleoServiceUpgrade.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/KaleoServiceUpgrade.java
@@ -142,6 +142,11 @@ public class KaleoServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"3.1.0", "3.1.1", new KaleoNotificationUpgradeProcess());
+
+		registry.register(
+			"3.1.1", "4.0.0",
+			new com.liferay.portal.workflow.kaleo.internal.upgrade.v4_0_0.
+				UpgradeKaleoDefinitionVersion());
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/KaleoDefinitionVersionUpgradeProcess.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/KaleoDefinitionVersionUpgradeProcess.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.internal.upgrade.v1_4_1;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -25,6 +26,7 @@ import com.liferay.portal.workflow.kaleo.internal.upgrade.v1_4_1.util.KaleoDefin
 
 import java.io.IOException;
 
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -194,47 +196,60 @@ public class KaleoDefinitionVersionUpgradeProcess extends UpgradeProcess {
 				}
 			}
 
-			PreparedStatement preparedStatement3 = connection.prepareStatement(
-				"select * from KaleoDraftDefinition where draftVersion != 1");
+			DBInspector dbInspector = new DBInspector(connection);
 
-			ResultSet resultSet2 = preparedStatement3.executeQuery();
+			DatabaseMetaData metaData = connection.getMetaData();
 
-			while (resultSet2.next()) {
-				long kaleoDefinitionVersionId = increment();
-				long groupId = resultSet2.getLong("groupId");
-				long companyId = resultSet2.getLong("companyId");
-				long userId = resultSet2.getLong("userId");
-				String userName = resultSet2.getString("userName");
-				Timestamp createDate = resultSet2.getTimestamp("createDate");
-				Timestamp modifiedDate = resultSet2.getTimestamp(
-					"modifiedDate");
-				String name = resultSet2.getString("name");
-				String title = resultSet2.getString("title");
-				String content = resultSet2.getString("content");
-				int version = resultSet2.getInt("version");
-				int draftVersion = resultSet2.getInt("draftVersion");
+			ResultSet metaDataResultSet = metaData.getTables(
+				dbInspector.getCatalog(), dbInspector.getSchema(),
+				"KaleoDraftDefinition", new String[] {"TABLE"});
 
-				preparedStatement2.setLong(1, kaleoDefinitionVersionId);
-				preparedStatement2.setLong(2, groupId);
-				preparedStatement2.setLong(3, companyId);
-				preparedStatement2.setLong(4, userId);
-				preparedStatement2.setString(5, userName);
-				preparedStatement2.setLong(6, userId);
-				preparedStatement2.setString(7, userName);
-				preparedStatement2.setTimestamp(8, modifiedDate);
-				preparedStatement2.setTimestamp(9, createDate);
-				preparedStatement2.setTimestamp(10, modifiedDate);
-				preparedStatement2.setString(11, name);
-				preparedStatement2.setString(12, title);
-				preparedStatement2.setString(13, StringPool.BLANK);
-				preparedStatement2.setString(14, content);
-				preparedStatement2.setString(
-					15, getVersion(version, draftVersion));
-				preparedStatement2.setLong(16, 0);
-				preparedStatement2.setInt(
-					17, WorkflowConstants.STATUS_APPROVED);
+			if (metaDataResultSet.next()) {
+				PreparedStatement preparedStatement3 =
+					connection.prepareStatement(
+						"select * from KaleoDraftDefinition where " +
+							"draftVersion != 1");
 
-				preparedStatement2.addBatch();
+				ResultSet resultSet2 = preparedStatement3.executeQuery();
+
+				while (resultSet2.next()) {
+					long kaleoDefinitionVersionId = increment();
+					long groupId = resultSet2.getLong("groupId");
+					long companyId = resultSet2.getLong("companyId");
+					long userId = resultSet2.getLong("userId");
+					String userName = resultSet2.getString("userName");
+					Timestamp createDate = resultSet2.getTimestamp(
+						"createDate");
+					Timestamp modifiedDate = resultSet2.getTimestamp(
+						"modifiedDate");
+					String name = resultSet2.getString("name");
+					String title = resultSet2.getString("title");
+					String content = resultSet2.getString("content");
+					int version = resultSet2.getInt("version");
+					int draftVersion = resultSet2.getInt("draftVersion");
+
+					preparedStatement2.setLong(1, kaleoDefinitionVersionId);
+					preparedStatement2.setLong(2, groupId);
+					preparedStatement2.setLong(3, companyId);
+					preparedStatement2.setLong(4, userId);
+					preparedStatement2.setString(5, userName);
+					preparedStatement2.setLong(6, userId);
+					preparedStatement2.setString(7, userName);
+					preparedStatement2.setTimestamp(8, modifiedDate);
+					preparedStatement2.setTimestamp(9, createDate);
+					preparedStatement2.setTimestamp(10, modifiedDate);
+					preparedStatement2.setString(11, name);
+					preparedStatement2.setString(12, title);
+					preparedStatement2.setString(13, StringPool.BLANK);
+					preparedStatement2.setString(14, content);
+					preparedStatement2.setString(
+						15, getVersion(version, draftVersion));
+					preparedStatement2.setLong(16, 0);
+					preparedStatement2.setInt(
+						17, WorkflowConstants.STATUS_APPROVED);
+
+					preparedStatement2.addBatch();
+				}
 			}
 
 			preparedStatement2.executeBatch();

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/KaleoDefinitionVersionUpgradeProcess.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/KaleoDefinitionVersionUpgradeProcess.java
@@ -61,6 +61,14 @@ public class KaleoDefinitionVersionUpgradeProcess extends UpgradeProcess {
 		return version + StringPool.PERIOD + 0;
 	}
 
+	protected String getVersion(int version, int draftVersion) {
+		if (version == 0) {
+			version = 1;
+		}
+
+		return version + StringPool.PERIOD + --draftVersion;
+	}
+
 	protected void removeDuplicateKaleoDefinitions()
 		throws IOException, SQLException {
 
@@ -184,6 +192,49 @@ public class KaleoDefinitionVersionUpgradeProcess extends UpgradeProcess {
 						preparedStatement, kaleoDefinitionId,
 						kaleoDefinitionVersionId);
 				}
+			}
+
+			PreparedStatement preparedStatement3 = connection.prepareStatement(
+				"select * from KaleoDraftDefinition where draftVersion != 1");
+
+			ResultSet resultSet2 = preparedStatement3.executeQuery();
+
+			while (resultSet2.next()) {
+				long kaleoDefinitionVersionId = increment();
+				long groupId = resultSet2.getLong("groupId");
+				long companyId = resultSet2.getLong("companyId");
+				long userId = resultSet2.getLong("userId");
+				String userName = resultSet2.getString("userName");
+				Timestamp createDate = resultSet2.getTimestamp("createDate");
+				Timestamp modifiedDate = resultSet2.getTimestamp(
+					"modifiedDate");
+				String name = resultSet2.getString("name");
+				String title = resultSet2.getString("title");
+				String content = resultSet2.getString("content");
+				int version = resultSet2.getInt("version");
+				int draftVersion = resultSet2.getInt("draftVersion");
+
+				preparedStatement2.setLong(1, kaleoDefinitionVersionId);
+				preparedStatement2.setLong(2, groupId);
+				preparedStatement2.setLong(3, companyId);
+				preparedStatement2.setLong(4, userId);
+				preparedStatement2.setString(5, userName);
+				preparedStatement2.setLong(6, userId);
+				preparedStatement2.setString(7, userName);
+				preparedStatement2.setTimestamp(8, modifiedDate);
+				preparedStatement2.setTimestamp(9, createDate);
+				preparedStatement2.setTimestamp(10, modifiedDate);
+				preparedStatement2.setString(11, name);
+				preparedStatement2.setString(12, title);
+				preparedStatement2.setString(13, StringPool.BLANK);
+				preparedStatement2.setString(14, content);
+				preparedStatement2.setString(
+					15, getVersion(version, draftVersion));
+				preparedStatement2.setLong(16, 0);
+				preparedStatement2.setInt(
+					17, WorkflowConstants.STATUS_APPROVED);
+
+				preparedStatement2.addBatch();
 			}
 
 			preparedStatement2.executeBatch();

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
@@ -14,8 +14,15 @@
 
 package com.liferay.portal.workflow.kaleo.internal.upgrade.v4_0_0;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.workflow.kaleo.internal.upgrade.v4_0_0.util.KaleoDefinitionVersionTable;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * @author Jesse Yeh
@@ -24,6 +31,58 @@ public class UpgradeKaleoDefinitionVersion extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("select kaleoDefinitionVersionId, name, version, ");
+		sb.append("kaleoDefinitionId from KaleoDefinitionVersion order by ");
+		sb.append("name, length(version), cast(version as decimal(4, 2)) asc");
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				sb.toString());
+			ResultSet resultSet = preparedStatement1.executeQuery();
+			PreparedStatement preparedStatement2 = connection.prepareStatement(
+				"update KaleoDefinitionVersion set version = ? where " +
+					"kaleoDefinitionVersionId = ?");
+			PreparedStatement preparedStatement3 = connection.prepareStatement(
+				"update KaleoDefinition set version = ? where " +
+					"kaleoDefinitionId = ?")) {
+
+			int count = 1;
+			String curName = null;
+			String previousName = null;
+
+			while (resultSet.next()) {
+				long kaleoDefinitionVersionId = resultSet.getLong(1);
+				curName = resultSet.getString(2);
+				long kaleoDefinitionId = resultSet.getLong(4);
+
+				if (StringUtil.equals(previousName, curName)) {
+					count++;
+				}
+				else {
+					count = 1;
+					previousName = curName;
+				}
+
+				preparedStatement2.setString(1, String.valueOf(count));
+				preparedStatement2.setLong(2, kaleoDefinitionVersionId);
+
+				preparedStatement2.addBatch();
+
+				preparedStatement3.setInt(1, count);
+				preparedStatement3.setLong(2, kaleoDefinitionId);
+
+				preparedStatement3.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+
+			preparedStatement3.executeBatch();
+		}
+		catch (SQLException sqlException) {
+			throw new UpgradeException(sqlException);
+		}
+
 		if (!hasColumnType("KaleoDefinitionVersion", "version", "INTEGER")) {
 			alter(
 				KaleoDefinitionVersionTable.class,

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
@@ -24,10 +24,10 @@ public class UpgradeKaleoDefinitionVersion extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (!hasColumnType("KaleoDefinitionVersion", "version", "INT")) {
+		if (!hasColumnType("KaleoDefinitionVersion", "version", "INTEGER")) {
 			alter(
 				KaleoDefinitionVersionTable.class,
-				new AlterColumnType("version", "INT"));
+				new AlterColumnType("version", "INTEGER"));
 		}
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
@@ -24,9 +24,11 @@ public class UpgradeKaleoDefinitionVersion extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		alter(
-			KaleoDefinitionVersionTable.class,
-			new AlterColumnType("version", "INT"));
+		if (!hasColumnType("KaleoDefinitionVersion", "version", "INT")) {
+			alter(
+				KaleoDefinitionVersionTable.class,
+				new AlterColumnType("version", "INT"));
+		}
 	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v4_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.workflow.kaleo.internal.upgrade.v4_0_0.util.KaleoDefinitionVersionTable;
+
+/**
+ * @author Jesse Yeh
+ */
+public class UpgradeKaleoDefinitionVersion extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		alter(
+			KaleoDefinitionVersionTable.class,
+			new AlterColumnType("version", "INT"));
+	}
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/util/KaleoDefinitionVersionTable.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/util/KaleoDefinitionVersionTable.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.upgrade.v4_0_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class KaleoDefinitionVersionTable {
+
+	public static final String TABLE_NAME = "KaleoDefinitionVersion";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT},
+		{"kaleoDefinitionVersionId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"kaleoDefinitionId", Types.BIGINT}, {"name", Types.VARCHAR},
+		{"title", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"content", Types.CLOB}, {"version", Types.INTEGER},
+		{"startKaleoNodeId", Types.BIGINT}, {"status", Types.INTEGER}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("kaleoDefinitionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("content", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("version", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("startKaleoNodeId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table KaleoDefinitionVersion (mvccVersion LONG default 0 not null,kaleoDefinitionVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionId LONG,name VARCHAR(200) null,title STRING null,description STRING null,content TEXT null,version INTEGER,startKaleoNodeId LONG,status INTEGER)";
+
+	public static final String TABLE_SQL_DROP =
+"drop table KaleoDefinitionVersion";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create unique index IX_AE02DCC on KaleoDefinitionVersion (companyId, name[$COLUMN_LENGTH:200$], version[$COLUMN_LENGTH:75$])"
+	};
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionCacheModel.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionCacheModel.java
@@ -202,13 +202,7 @@ public class KaleoDefinitionVersionCacheModel
 			kaleoDefinitionVersionImpl.setContent(content);
 		}
 
-		if (version == null) {
-			kaleoDefinitionVersionImpl.setVersion("");
-		}
-		else {
-			kaleoDefinitionVersionImpl.setVersion(version);
-		}
-
+		kaleoDefinitionVersionImpl.setVersion(version);
 		kaleoDefinitionVersionImpl.setStartKaleoNodeId(startKaleoNodeId);
 		kaleoDefinitionVersionImpl.setStatus(status);
 
@@ -243,7 +237,8 @@ public class KaleoDefinitionVersionCacheModel
 		title = objectInput.readUTF();
 		description = objectInput.readUTF();
 		content = (String)objectInput.readObject();
-		version = objectInput.readUTF();
+
+		version = objectInput.readInt();
 
 		startKaleoNodeId = objectInput.readLong();
 
@@ -312,12 +307,7 @@ public class KaleoDefinitionVersionCacheModel
 			objectOutput.writeObject(content);
 		}
 
-		if (version == null) {
-			objectOutput.writeUTF("");
-		}
-		else {
-			objectOutput.writeUTF(version);
-		}
+		objectOutput.writeInt(version);
 
 		objectOutput.writeLong(startKaleoNodeId);
 
@@ -340,7 +330,7 @@ public class KaleoDefinitionVersionCacheModel
 	public String title;
 	public String description;
 	public String content;
-	public String version;
+	public int version;
 	public long startKaleoNodeId;
 	public int status;
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionModelImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionModelImpl.java
@@ -86,7 +86,7 @@ public class KaleoDefinitionVersionModelImpl
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"kaleoDefinitionId", Types.BIGINT}, {"name", Types.VARCHAR},
 		{"title", Types.VARCHAR}, {"description", Types.VARCHAR},
-		{"content", Types.CLOB}, {"version", Types.VARCHAR},
+		{"content", Types.CLOB}, {"version", Types.INTEGER},
 		{"startKaleoNodeId", Types.BIGINT}, {"status", Types.INTEGER}
 	};
 
@@ -110,13 +110,13 @@ public class KaleoDefinitionVersionModelImpl
 		TABLE_COLUMNS_MAP.put("title", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("content", Types.CLOB);
-		TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("version", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("startKaleoNodeId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table KaleoDefinitionVersion (mvccVersion LONG default 0 not null,kaleoDefinitionVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionId LONG,name VARCHAR(200) null,title STRING null,description STRING null,content TEXT null,version VARCHAR(75) null,startKaleoNodeId LONG,status INTEGER)";
+		"create table KaleoDefinitionVersion (mvccVersion LONG default 0 not null,kaleoDefinitionVersionId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,createDate DATE null,modifiedDate DATE null,kaleoDefinitionId LONG,name VARCHAR(200) null,title STRING null,description STRING null,content TEXT null,version INTEGER,startKaleoNodeId LONG,status INTEGER)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table KaleoDefinitionVersion";
@@ -400,7 +400,7 @@ public class KaleoDefinitionVersionModelImpl
 			"version", KaleoDefinitionVersion::getVersion);
 		attributeSetterBiConsumers.put(
 			"version",
-			(BiConsumer<KaleoDefinitionVersion, String>)
+			(BiConsumer<KaleoDefinitionVersion, Integer>)
 				KaleoDefinitionVersion::setVersion);
 		attributeGetterFunctions.put(
 			"startKaleoNodeId", KaleoDefinitionVersion::getStartKaleoNodeId);
@@ -822,17 +822,12 @@ public class KaleoDefinitionVersionModelImpl
 	}
 
 	@Override
-	public String getVersion() {
-		if (_version == null) {
-			return "";
-		}
-		else {
-			return _version;
-		}
+	public int getVersion() {
+		return _version;
 	}
 
 	@Override
-	public void setVersion(String version) {
+	public void setVersion(int version) {
 		if (_columnOriginalValues == Collections.EMPTY_MAP) {
 			_setColumnOriginalValues();
 		}
@@ -845,8 +840,9 @@ public class KaleoDefinitionVersionModelImpl
 	 *             #getColumnOriginalValue(String)}
 	 */
 	@Deprecated
-	public String getOriginalVersion() {
-		return getColumnOriginalValue("version");
+	public int getOriginalVersion() {
+		return GetterUtil.getInteger(
+			this.<Integer>getColumnOriginalValue("version"));
 	}
 
 	@Override
@@ -1278,12 +1274,6 @@ public class KaleoDefinitionVersionModelImpl
 
 		kaleoDefinitionVersionCacheModel.version = getVersion();
 
-		String version = kaleoDefinitionVersionCacheModel.version;
-
-		if ((version != null) && (version.length() == 0)) {
-			kaleoDefinitionVersionCacheModel.version = null;
-		}
-
 		kaleoDefinitionVersionCacheModel.startKaleoNodeId =
 			getStartKaleoNodeId();
 
@@ -1382,7 +1372,7 @@ public class KaleoDefinitionVersionModelImpl
 	private String _titleCurrentLanguageId;
 	private String _description;
 	private String _content;
-	private String _version;
+	private int _version;
 	private long _startKaleoNodeId;
 	private int _status;
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.workflow.kaleo.service.impl;
 
 import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.exception.IncompleteWorkflowInstancesException;
@@ -94,7 +96,7 @@ public class KaleoDefinitionVersionLocalServiceImpl
 		kaleoDefinitionVersion.setTitle(title);
 		kaleoDefinitionVersion.setDescription(description);
 		kaleoDefinitionVersion.setContent(content);
-		kaleoDefinitionVersion.setVersion(version);
+		kaleoDefinitionVersion.setVersion(getVersion(version));
 
 		int status = GetterUtil.getInteger(
 			serviceContext.getAttribute("status"),
@@ -210,7 +212,7 @@ public class KaleoDefinitionVersionLocalServiceImpl
 		long companyId, String name, String version) {
 
 		return kaleoDefinitionVersionPersistence.fetchByC_N_V(
-			companyId, name, version);
+			companyId, name, getVersion(version));
 	}
 
 	@Override
@@ -247,7 +249,7 @@ public class KaleoDefinitionVersionLocalServiceImpl
 		throws PortalException {
 
 		return kaleoDefinitionVersionPersistence.findByC_N_V(
-			companyId, name, version);
+			companyId, name, getVersion(version));
 	}
 
 	@Override
@@ -293,7 +295,7 @@ public class KaleoDefinitionVersionLocalServiceImpl
 
 		KaleoDefinitionVersion kaleoDefinitionVersion =
 			kaleoDefinitionVersionPersistence.findByC_N_V(
-				companyId, name, version);
+				companyId, name, getVersion(version));
 
 		return kaleoDefinitionVersionPersistence.findByC_N_PrevAndNext(
 			kaleoDefinitionVersion.getKaleoDefinitionVersionId(), companyId,
@@ -410,6 +412,12 @@ public class KaleoDefinitionVersionLocalServiceImpl
 		}
 
 		return kaleoDefinitionVersionIds;
+	}
+
+	protected int getVersion(String version) {
+		int[] versionParts = StringUtil.split(version, StringPool.PERIOD, 0);
+
+		return versionParts[0];
 	}
 
 	@Reference

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/impl/KaleoDefinitionVersionPersistenceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/impl/KaleoDefinitionVersionPersistenceImpl.java
@@ -1201,7 +1201,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 	 */
 	@Override
 	public KaleoDefinitionVersion findByC_N_V(
-			long companyId, String name, String version)
+			long companyId, String name, int version)
 		throws NoSuchDefinitionVersionException {
 
 		KaleoDefinitionVersion kaleoDefinitionVersion = fetchByC_N_V(
@@ -1243,7 +1243,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 	 */
 	@Override
 	public KaleoDefinitionVersion fetchByC_N_V(
-		long companyId, String name, String version) {
+		long companyId, String name, int version) {
 
 		return fetchByC_N_V(companyId, name, version, true);
 	}
@@ -1259,10 +1259,9 @@ public class KaleoDefinitionVersionPersistenceImpl
 	 */
 	@Override
 	public KaleoDefinitionVersion fetchByC_N_V(
-		long companyId, String name, String version, boolean useFinderCache) {
+		long companyId, String name, int version, boolean useFinderCache) {
 
 		name = Objects.toString(name, "");
-		version = Objects.toString(version, "");
 
 		Object[] finderArgs = null;
 
@@ -1282,7 +1281,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 
 			if ((companyId != kaleoDefinitionVersion.getCompanyId()) ||
 				!Objects.equals(name, kaleoDefinitionVersion.getName()) ||
-				!Objects.equals(version, kaleoDefinitionVersion.getVersion())) {
+				(version != kaleoDefinitionVersion.getVersion())) {
 
 				result = null;
 			}
@@ -1306,16 +1305,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 				sb.append(_FINDER_COLUMN_C_N_V_NAME_2);
 			}
 
-			boolean bindVersion = false;
-
-			if (version.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_N_V_VERSION_3);
-			}
-			else {
-				bindVersion = true;
-
-				sb.append(_FINDER_COLUMN_C_N_V_VERSION_2);
-			}
+			sb.append(_FINDER_COLUMN_C_N_V_VERSION_2);
 
 			String sql = sb.toString();
 
@@ -1334,9 +1324,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 					queryPos.add(name);
 				}
 
-				if (bindVersion) {
-					queryPos.add(version);
-				}
+				queryPos.add(version);
 
 				List<KaleoDefinitionVersion> list = query.list();
 
@@ -1380,7 +1368,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 	 */
 	@Override
 	public KaleoDefinitionVersion removeByC_N_V(
-			long companyId, String name, String version)
+			long companyId, String name, int version)
 		throws NoSuchDefinitionVersionException {
 
 		KaleoDefinitionVersion kaleoDefinitionVersion = findByC_N_V(
@@ -1398,9 +1386,8 @@ public class KaleoDefinitionVersionPersistenceImpl
 	 * @return the number of matching kaleo definition versions
 	 */
 	@Override
-	public int countByC_N_V(long companyId, String name, String version) {
+	public int countByC_N_V(long companyId, String name, int version) {
 		name = Objects.toString(name, "");
-		version = Objects.toString(version, "");
 
 		FinderPath finderPath = _finderPathCountByC_N_V;
 
@@ -1426,16 +1413,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 				sb.append(_FINDER_COLUMN_C_N_V_NAME_2);
 			}
 
-			boolean bindVersion = false;
-
-			if (version.isEmpty()) {
-				sb.append(_FINDER_COLUMN_C_N_V_VERSION_3);
-			}
-			else {
-				bindVersion = true;
-
-				sb.append(_FINDER_COLUMN_C_N_V_VERSION_2);
-			}
+			sb.append(_FINDER_COLUMN_C_N_V_VERSION_2);
 
 			String sql = sb.toString();
 
@@ -1454,9 +1432,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 					queryPos.add(name);
 				}
 
-				if (bindVersion) {
-					queryPos.add(version);
-				}
+				queryPos.add(version);
 
 				count = (Long)query.uniqueResult();
 
@@ -1484,9 +1460,6 @@ public class KaleoDefinitionVersionPersistenceImpl
 
 	private static final String _FINDER_COLUMN_C_N_V_VERSION_2 =
 		"kaleoDefinitionVersion.version = ?";
-
-	private static final String _FINDER_COLUMN_C_N_V_VERSION_3 =
-		"(kaleoDefinitionVersion.version IS NULL OR kaleoDefinitionVersion.version = '')";
 
 	public KaleoDefinitionVersionPersistenceImpl() {
 		setModelClass(KaleoDefinitionVersion.class);
@@ -2119,7 +2092,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 			FINDER_CLASS_NAME_ENTITY, "fetchByC_N_V",
 			new String[] {
 				Long.class.getName(), String.class.getName(),
-				String.class.getName()
+				Integer.class.getName()
 			},
 			new String[] {"companyId", "name", "version"}, true);
 
@@ -2127,7 +2100,7 @@ public class KaleoDefinitionVersionPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_V",
 			new String[] {
 				Long.class.getName(), String.class.getName(),
-				String.class.getName()
+				Integer.class.getName()
 			},
 			new String[] {"companyId", "name", "version"}, false);
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/module-hbm.xml
@@ -101,7 +101,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="title" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="content" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="startKaleoNodeId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="status" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -115,7 +115,7 @@
 		<field name="content" type="String">
 			<hint-collection name="CLOB" />
 		</field>
-		<field name="version" type="String" />
+		<field name="version" type="int" />
 		<field name="startKaleoNodeId" type="long" />
 		<field name="status" type="int" />
 	</model>

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/sql/indexes.sql
@@ -11,7 +11,7 @@ create index IX_4C23F11B on KaleoDefinition (companyId, name[$COLUMN_LENGTH:200$
 create index IX_EC14F81A on KaleoDefinition (companyId, name[$COLUMN_LENGTH:200$], version);
 create index IX_241376B4 on KaleoDefinition (companyId, scope[$COLUMN_LENGTH:75$], active_);
 
-create unique index IX_AE02DCC on KaleoDefinitionVersion (companyId, name[$COLUMN_LENGTH:200$], version[$COLUMN_LENGTH:75$]);
+create unique index IX_AE02DCC on KaleoDefinitionVersion (companyId, name[$COLUMN_LENGTH:200$], version);
 
 create index IX_58D85ECB on KaleoInstance (className[$COLUMN_LENGTH:200$], classPK);
 create index IX_BF5839F8 on KaleoInstance (companyId, kaleoDefinitionName[$COLUMN_LENGTH:200$], kaleoDefinitionVersion, completionDate);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/sql/tables.sql
@@ -73,7 +73,7 @@ create table KaleoDefinitionVersion (
 	title STRING null,
 	description STRING null,
 	content TEXT null,
-	version VARCHAR(75) null,
+	version INTEGER,
 	startKaleoNodeId LONG,
 	status INTEGER
 );

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionVersionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionVersionPersistenceTest.java
@@ -161,7 +161,7 @@ public class KaleoDefinitionVersionPersistenceTest {
 
 		newKaleoDefinitionVersion.setContent(RandomTestUtil.randomString());
 
-		newKaleoDefinitionVersion.setVersion(RandomTestUtil.randomString());
+		newKaleoDefinitionVersion.setVersion(RandomTestUtil.nextInt());
 
 		newKaleoDefinitionVersion.setStartKaleoNodeId(
 			RandomTestUtil.nextLong());
@@ -256,11 +256,12 @@ public class KaleoDefinitionVersionPersistenceTest {
 
 	@Test
 	public void testCountByC_N_V() throws Exception {
-		_persistence.countByC_N_V(RandomTestUtil.nextLong(), "", "");
+		_persistence.countByC_N_V(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
 
-		_persistence.countByC_N_V(0L, "null", "null");
+		_persistence.countByC_N_V(0L, "null", 0);
 
-		_persistence.countByC_N_V(0L, (String)null, (String)null);
+		_persistence.countByC_N_V(0L, (String)null, 0);
 	}
 
 	@Test
@@ -604,8 +605,8 @@ public class KaleoDefinitionVersionPersistenceTest {
 				kaleoDefinitionVersion, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "name"));
 		Assert.assertEquals(
-			kaleoDefinitionVersion.getVersion(),
-			ReflectionTestUtil.invoke(
+			Integer.valueOf(kaleoDefinitionVersion.getVersion()),
+			ReflectionTestUtil.<Integer>invoke(
 				kaleoDefinitionVersion, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "version"));
 	}
@@ -648,7 +649,7 @@ public class KaleoDefinitionVersionPersistenceTest {
 
 		kaleoDefinitionVersion.setContent(RandomTestUtil.randomString());
 
-		kaleoDefinitionVersion.setVersion(RandomTestUtil.randomString());
+		kaleoDefinitionVersion.setVersion(RandomTestUtil.nextInt());
 
 		kaleoDefinitionVersion.setStartKaleoNodeId(RandomTestUtil.nextLong());
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionLocalServiceTest.java
@@ -44,7 +44,7 @@ public class KaleoDefinitionVersionLocalServiceTest
 				kaleoDefinition.getCompanyId(), kaleoDefinition.getName(),
 				_getVersion(kaleoDefinition.getVersion()));
 
-		Assert.assertEquals("1.0", kaleoDefinitionVersion.getVersion());
+		Assert.assertEquals(1, kaleoDefinitionVersion.getVersion());
 	}
 
 	@Test(expected = NoSuchDefinitionVersionException.class)
@@ -75,7 +75,7 @@ public class KaleoDefinitionVersionLocalServiceTest
 				kaleoDefinition.getCompanyId(), kaleoDefinition.getName(),
 				_getVersion(kaleoDefinition.getVersion()));
 
-		Assert.assertEquals("2.0", kaleoDefinitionVersion.getVersion());
+		Assert.assertEquals(2, kaleoDefinitionVersion.getVersion());
 	}
 
 	@Inject

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/action/BaseKaleoDesignerMVCActionCommand.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/action/BaseKaleoDesignerMVCActionCommand.java
@@ -203,7 +203,8 @@ public abstract class BaseKaleoDesignerMVCActionCommand
 		portletURL.setParameter(
 			"name", kaleoDefinitionVersion.getName(), false);
 		portletURL.setParameter(
-			"draftVersion", kaleoDefinitionVersion.getVersion(), false);
+			"draftVersion", String.valueOf(kaleoDefinitionVersion.getVersion()),
+			false);
 
 		portletURL.setWindowState(actionRequest.getWindowState());
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/upgrade/KaleoDesignerWebUpgrade.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/upgrade/KaleoDesignerWebUpgrade.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.workflow.kaleo.designer.web.internal.upgrade.v1_0_0.UpgradePortletId;
-import com.liferay.portal.workflow.kaleo.designer.web.internal.upgrade.v1_0_1.KaleoDefinitionVersionUpgradeProcess;
 import com.liferay.portal.workflow.kaleo.designer.web.internal.upgrade.v1_0_2.KaleoDefinitionUpgradeProcess;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
@@ -40,11 +39,7 @@ public class KaleoDesignerWebUpgrade implements UpgradeStepRegistrator {
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
 
-		registry.register(
-			"1.0.0", "1.0.1",
-			new KaleoDefinitionVersionUpgradeProcess(
-				_counterLocalService, _kaleoDefinitionLocalService,
-				_kaleoDefinitionVersionLocalService, _userLocalService));
+		registry.register("1.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register(
 			"1.0.1", "1.0.2",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -51,11 +51,11 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 				name = kaleoDefinitionVersion.getName();
 			}
 
-			draftVersion = kaleoDefinitionVersion.getVersion();
+			draftVersion = String.valueOf(kaleoDefinitionVersion.getVersion());
 
 			latestKaleoDefinitionVersion = KaleoDefinitionVersionLocalServiceUtil.getLatestKaleoDefinitionVersion(themeDisplay.getCompanyId(), name);
 
-			latestDraftVersion = latestKaleoDefinitionVersion.getVersion();
+			latestDraftVersion = String.valueOf(latestKaleoDefinitionVersion.getVersion());
 
 			if (kaleoDefinition != null) {
 				version = kaleoDefinition.getVersion();
@@ -741,7 +741,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 									<portlet:param name="mvcPath" value='<%= "/designer/edit_kaleo_definition_version.jsp" %>' />
 									<portlet:param name="redirect" value="<%= currentURL %>" />
 									<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-									<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+									<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 								</portlet:renderURL>
 
 								<aui:button-row>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/kaleo_definition_version_action.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/kaleo_definition_version_action.jsp
@@ -46,7 +46,7 @@ String kaleoNamespace = PortalUtil.getPortletNamespace(KaleoDesignerPortletKeys.
 		<portlet:param name="mvcPath" value="/designer/edit_kaleo_definition_version.jsp" />
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-		<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+		<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 		<portlet:param name="<%= WorkflowWebKeys.WORKFLOW_JSP_STATE %>" value="view" />
 	</liferay-portlet:renderURL>
 
@@ -60,7 +60,7 @@ String kaleoNamespace = PortalUtil.getPortletNamespace(KaleoDesignerPortletKeys.
 			<portlet:param name="mvcPath" value='<%= "/designer/edit_kaleo_definition_version.jsp" %>' />
 			<portlet:param name="redirect" value="<%= currentURL %>" />
 			<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-			<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+			<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 		</liferay-portlet:renderURL>
 
 		<liferay-ui:icon
@@ -115,7 +115,7 @@ String kaleoNamespace = PortalUtil.getPortletNamespace(KaleoDesignerPortletKeys.
 				<liferay-portlet:actionURL name="/portal_workflow/delete_workflow_definition" portletName="<%= KaleoDesignerPortletKeys.CONTROL_PANEL_WORKFLOW %>" var="deleteURL">
 					<portlet:param name="redirect" value="<%= currentURL %>" />
 					<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-					<portlet:param name="version" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+					<portlet:param name="version" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 				</liferay-portlet:actionURL>
 
 				<liferay-ui:icon

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/kaleo_definition_version_history_action.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/kaleo_definition_version_history_action.jsp
@@ -30,14 +30,14 @@ KaleoDefinitionVersion kaleoDefinitionVersion = (KaleoDefinitionVersion)row.getO
 	<portlet:param name="mvcPath" value="/designer/edit_kaleo_definition_version.jsp" />
 	<portlet:param name="redirect" value="<%= currentURL %>" />
 	<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-	<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+	<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 	<portlet:param name="<%= WorkflowWebKeys.WORKFLOW_JSP_STATE %>" value="<%= WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_STATE %>" />
 </portlet:renderURL>
 
 <liferay-portlet:actionURL name="/kaleo_designer/revert_kaleo_definition_version" var="revertURL">
 	<portlet:param name="redirect" value="<%= redirect %>" />
 	<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-	<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+	<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 </liferay-portlet:actionURL>
 
 <c:if test="<%= !Objects.equals(kaleoDefinitionVersion.getVersion(), currentKaleoDefinitionVersion.getVersion()) %>">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
@@ -53,7 +53,7 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 				<portlet:param name="mvcPath" value='<%= "/designer/edit_kaleo_definition_version.jsp" %>' />
 				<portlet:param name="redirect" value="<%= currentURL %>" />
 				<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-				<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+				<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 				<portlet:param name="clearSessionMessage" value="true" />
 			</liferay-portlet:renderURL>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/kaleo_draft_definition_action.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/kaleo_draft_definition_action.jsp
@@ -36,7 +36,7 @@ KaleoDefinitionVersion kaleoDefinitionVersion = (KaleoDefinitionVersion)row.getO
 			<portlet:param name="closeRedirect" value='<%= (String)row.getParameter("backURL") %>' />
 			<portlet:param name="historyKey" value="workflow" />
 			<portlet:param name="name" value="<%= kaleoDefinitionVersion.getName() %>" />
-			<portlet:param name="draftVersion" value="<%= kaleoDefinitionVersion.getVersion() %>" />
+			<portlet:param name="draftVersion" value="<%= String.valueOf(kaleoDefinitionVersion.getVersion()) %>" />
 		</liferay-portlet:renderURL>
 
 		<liferay-ui:icon

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoDefinitionModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoDefinitionModelListener.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.workflow.kaleo.metrics.integration.internal.model.listener;
 
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
@@ -47,8 +45,7 @@ public class KaleoDefinitionModelListener
 			kaleoDefinition.getKaleoDefinitionId(),
 			kaleoDefinition.getTitle(defaultLanguageId),
 			kaleoDefinition.getTitleMap(),
-			StringBundler.concat(
-				kaleoDefinition.getVersion(), CharPool.PERIOD, 0));
+			String.valueOf(kaleoDefinition.getVersion()));
 	}
 
 	@Override
@@ -64,8 +61,7 @@ public class KaleoDefinitionModelListener
 			kaleoDefinition.getKaleoDefinitionId(),
 			kaleoDefinition.getTitle(defaultLanguageId),
 			kaleoDefinition.getTitleMap(),
-			StringBundler.concat(
-				kaleoDefinition.getVersion(), CharPool.PERIOD, 0));
+			String.valueOf(kaleoDefinition.getVersion()));
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoInstanceModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoInstanceModelListener.java
@@ -56,8 +56,8 @@ public class KaleoInstanceModelListener
 			kaleoInstance.getCompanyId(), null, kaleoInstance.getCreateDate(),
 			kaleoInstance.getKaleoInstanceId(), kaleoInstance.getModifiedDate(),
 			kaleoInstance.getKaleoDefinitionId(),
-			kaleoDefinitionVersion.getVersion(), kaleoInstance.getUserId(),
-			kaleoInstance.getUserName());
+			String.valueOf(kaleoDefinitionVersion.getVersion()),
+			kaleoInstance.getUserId(), kaleoInstance.getUserName());
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoNodeModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoNodeModelListener.java
@@ -49,8 +49,8 @@ public class KaleoNodeModelListener extends BaseKaleoModelListener<KaleoNode> {
 			kaleoNode.isInitial(), kaleoNode.getModifiedDate(),
 			kaleoNode.getName(), kaleoNode.getKaleoNodeId(),
 			kaleoNode.getKaleoDefinitionId(),
-			kaleoDefinitionVersion.getVersion(), kaleoNode.isTerminal(),
-			kaleoNode.getType());
+			String.valueOf(kaleoDefinitionVersion.getVersion()),
+			kaleoNode.isTerminal(), kaleoNode.getType());
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTaskInstanceTokenModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTaskInstanceTokenModelListener.java
@@ -109,7 +109,7 @@ public class KaleoTaskInstanceTokenModelListener
 					kaleoTaskInstanceToken.getKaleoTaskName(),
 					kaleoTaskInstanceToken.getKaleoTaskId(),
 					kaleoTaskInstanceToken.getKaleoDefinitionId(),
-					kaleoDefinitionVersion.getVersion(),
+					String.valueOf(kaleoDefinitionVersion.getVersion()),
 					kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(),
 					kaleoTaskInstanceToken.getUserId());
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTaskModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTaskModelListener.java
@@ -44,7 +44,8 @@ public class KaleoTaskModelListener extends BaseKaleoModelListener<KaleoTask> {
 			kaleoTask.getCompanyId(), kaleoTask.getCreateDate(), false,
 			kaleoTask.getModifiedDate(), kaleoTask.getName(),
 			kaleoTask.getKaleoTaskId(), kaleoTask.getKaleoDefinitionId(),
-			kaleoDefinitionVersion.getVersion(), false, NodeType.TASK.name());
+			String.valueOf(kaleoDefinitionVersion.getVersion()), false,
+			NodeType.TASK.name());
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTransitionModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTransitionModelListener.java
@@ -54,7 +54,7 @@ public class KaleoTransitionModelListener
 				kaleoTransition.getModifiedDate(), kaleoTransition.getName(),
 				_getNodeId(kaleoTransition.getKaleoNodeId()),
 				kaleoTransition.getKaleoDefinitionId(),
-				kaleoDefinitionVersion.getVersion(),
+				String.valueOf(kaleoDefinitionVersion.getVersion()),
 				_getNodeId(kaleoTransition.getSourceKaleoNodeId()),
 				kaleoTransition.getSourceKaleoNodeName(),
 				_getNodeId(kaleoTransition.getTargetKaleoNodeId()),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
@@ -84,7 +84,7 @@ public class InstanceWorkflowMetricsReindexer
 					kaleoInstance.getKaleoInstanceId(),
 					kaleoInstance.getModifiedDate(),
 					kaleoInstance.getKaleoDefinitionId(),
-					kaleoDefinitionVersion.getVersion(),
+					String.valueOf(kaleoDefinitionVersion.getVersion()),
 					kaleoInstance.getUserId(), kaleoInstance.getUserName());
 
 				_workflowMetricsReindexStatusMessageSender.sendStatusMessage(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/NodeWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/NodeWorkflowMetricsReindexer.java
@@ -83,8 +83,8 @@ public class NodeWorkflowMetricsReindexer implements WorkflowMetricsReindexer {
 					kaleoNode.isInitial(), kaleoNode.getModifiedDate(),
 					kaleoNode.getName(), kaleoNode.getKaleoNodeId(),
 					kaleoNode.getKaleoDefinitionId(),
-					kaleoDefinitionVersion.getVersion(), kaleoNode.isTerminal(),
-					kaleoNode.getType());
+					String.valueOf(kaleoDefinitionVersion.getVersion()),
+					kaleoNode.isTerminal(), kaleoNode.getType());
 			});
 
 		actionableDynamicQuery.performActions();
@@ -124,7 +124,7 @@ public class NodeWorkflowMetricsReindexer implements WorkflowMetricsReindexer {
 					kaleoTask.getModifiedDate(), kaleoTask.getName(),
 					kaleoTask.getKaleoTaskId(),
 					kaleoTask.getKaleoDefinitionId(),
-					kaleoDefinitionVersion.getVersion(), false,
+					String.valueOf(kaleoDefinitionVersion.getVersion()), false,
 					NodeType.TASK.name());
 
 				_workflowMetricsReindexStatusMessageSender.sendStatusMessage(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/ProcessWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/ProcessWorkflowMetricsReindexer.java
@@ -14,15 +14,12 @@
 
 package com.liferay.portal.workflow.kaleo.metrics.integration.internal.search.index.reindexer;
 
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
-import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
 import com.liferay.portal.workflow.metrics.search.background.task.WorkflowMetricsReindexStatusMessageSender;
@@ -78,8 +75,7 @@ public class ProcessWorkflowMetricsReindexer
 					kaleoDefinition.getKaleoDefinitionId(),
 					kaleoDefinition.getTitle(defaultLanguageId),
 					kaleoDefinition.getTitleMap(),
-					StringBundler.concat(
-						kaleoDefinition.getVersion(), CharPool.PERIOD, 0),
+					String.valueOf(kaleoDefinition.getVersion()),
 					Stream.of(
 						_kaleoDefinitionVersionLocalService.
 							getKaleoDefinitionVersions(
@@ -87,7 +83,7 @@ public class ProcessWorkflowMetricsReindexer
 					).flatMap(
 						List::stream
 					).map(
-						KaleoDefinitionVersion::getVersion
+						kdv -> String.valueOf(kdv.getVersion())
 					).toArray(
 						String[]::new
 					));

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
@@ -143,7 +143,7 @@ public class TaskWorkflowMetricsReindexer implements WorkflowMetricsReindexer {
 					kaleoTaskInstanceToken.getKaleoTaskName(),
 					kaleoTaskInstanceToken.getKaleoTaskId(),
 					kaleoInstance.getKaleoDefinitionId(),
-					kaleoDefinitionVersion.getVersion(),
+					String.valueOf(kaleoDefinitionVersion.getVersion()),
 					kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(),
 					kaleoTaskInstanceToken.getUserId());
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TransitionWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TransitionWorkflowMetricsReindexer.java
@@ -83,7 +83,7 @@ public class TransitionWorkflowMetricsReindexer
 					kaleoTransition.getName(),
 					_getNodeId(kaleoTransition.getKaleoNodeId()),
 					kaleoTransition.getKaleoDefinitionId(),
-					kaleoDefinitionVersion.getVersion(),
+					String.valueOf(kaleoDefinitionVersion.getVersion()),
 					_getNodeId(kaleoTransition.getSourceKaleoNodeId()),
 					kaleoTransition.getSourceKaleoNodeName(),
 					_getNodeId(kaleoTransition.getTargetKaleoNodeId()),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/AssigneeMetricResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/AssigneeMetricResourceTest.java
@@ -542,8 +542,7 @@ public class AssigneeMetricResourceTest
 		for (NodeMetric nodeMetric : nodeMetrics) {
 			_workflowMetricsRESTTestHelper.addNodeMetric(
 				assignee, testGroup.getCompanyId(), instanceSupplier,
-				nodeMetric, processId, status, TestPropsValues.getUser(),
-				"1.0");
+				nodeMetric, processId, status, TestPropsValues.getUser(), "1");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeMetricResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeMetricResourceTest.java
@@ -398,7 +398,7 @@ public class NodeMetricResourceTest extends BaseNodeMetricResourceTestCase {
 		throws Exception {
 
 		return testGetProcessNodeMetricsPage_addNodeMetric(
-			processId, nodeMetric, "1.0");
+			processId, nodeMetric, "1");
 	}
 
 	protected NodeMetric testGetProcessNodeMetricsPage_addNodeMetric(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeResourceTest.java
@@ -117,7 +117,7 @@ public class NodeResourceTest extends BaseNodeResourceTestCase {
 	protected Node testGetProcessNodesPage_addNode(Long processId, Node node)
 		throws Exception {
 
-		return _addNode(node, processId, "1.0");
+		return _addNode(node, processId, "1");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/SLAResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/SLAResourceTest.java
@@ -58,7 +58,7 @@ public class SLAResourceTest extends BaseSLAResourceTestCase {
 			testGroup.getCompanyId());
 
 		_node = _workflowMetricsRESTTestHelper.addNode(
-			testGroup.getCompanyId(), _process.getId(), "1.0");
+			testGroup.getCompanyId(), _process.getId(), "1");
 	}
 
 	@After

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
@@ -241,7 +241,7 @@ public class WorkflowMetricsRESTTestHelper {
 
 		return addNodeMetric(
 			assignee, companyId, instanceSuplier, task, processId, status, user,
-			"1.0");
+			"1");
 	}
 
 	public NodeMetric addNodeMetric(
@@ -298,7 +298,7 @@ public class WorkflowMetricsRESTTestHelper {
 			{
 				id = RandomTestUtil.randomLong();
 				title = RandomTestUtil.randomString();
-				version = "1.0";
+				version = "1";
 			}
 		};
 
@@ -339,7 +339,7 @@ public class WorkflowMetricsRESTTestHelper {
 	}
 
 	public ProcessMetric addProcessMetric(long companyId) throws Exception {
-		return addProcessMetric(companyId, "1.0");
+		return addProcessMetric(companyId, "1");
 	}
 
 	public ProcessMetric addProcessMetric(
@@ -507,7 +507,7 @@ public class WorkflowMetricsRESTTestHelper {
 		task.setName(name);
 		task.setNodeId(nodeId);
 		task.setProcessId(processId);
-		task.setProcessVersion("1.0");
+		task.setProcessVersion("1");
 
 		return addTask(companyId, instance, task, user);
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/service/impl/WorkflowMetricsSLADefinitionLocalServiceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/service/impl/WorkflowMetricsSLADefinitionLocalServiceImpl.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.workflow.metrics.service.impl;
 
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -369,10 +368,15 @@ public class WorkflowMetricsSLADefinitionLocalServiceImpl
 	}
 
 	protected String getNextVersion(String version) {
-		int[] versionParts = StringUtil.split(version, StringPool.PERIOD, 0);
+		try {
+			return String.valueOf(Integer.parseInt(version) + 1);
+		}
+		catch (NumberFormatException numberFormatException) {
+			int[] versionParts = StringUtil.split(
+				version, StringPool.PERIOD, 0);
 
-		return StringBundler.concat(
-			++versionParts[0], StringPool.PERIOD, versionParts[1]);
+			return String.valueOf(++versionParts[0]);
+		}
 	}
 
 	protected void validate(
@@ -576,7 +580,7 @@ public class WorkflowMetricsSLADefinitionLocalServiceImpl
 		return buckets.size();
 	}
 
-	private static final String _VERSION_DEFAULT = "1.0";
+	private static final String _VERSION_DEFAULT = "1";
 
 	@Reference
 	private Aggregations _aggregations;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/messaging/test/WorkflowMetricsSLADefinitionTransformerMessageListenerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/messaging/test/WorkflowMetricsSLADefinitionTransformerMessageListenerTest.java
@@ -50,13 +50,13 @@ public class WorkflowMetricsSLADefinitionTransformerMessageListenerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsNodeType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1);
 		assertCount(
 			_processWorkflowMetricsIndexNameBuilder.getIndexName(
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "active", true, "companyId",
 			workflowDefinition.getCompanyId(), "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1);
 
 		WorkflowMetricsSLADefinition workflowMetricsSLADefinition =
 			_workflowMetricsSLADefinitionLocalService.
@@ -74,14 +74,14 @@ public class WorkflowMetricsSLADefinitionTransformerMessageListenerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "active", true, "companyId",
 			workflowDefinition.getCompanyId(), "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "2.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 2);
 		assertCount(
 			4,
 			_nodeWorkflowMetricsIndexNameBuilder.getIndexName(
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsNodeType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "2.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 2);
 
 		_workflowMetricsSLADefinitionTransformerMessageListener.receive(
 			new Message());
@@ -92,16 +92,16 @@ public class WorkflowMetricsSLADefinitionTransformerMessageListenerTest
 					getWorkflowMetricsSLADefinitionVersion(
 						workflowMetricsSLADefinition.
 							getWorkflowMetricsSLADefinitionId(),
-						"2.0");
+						"2");
 
 		Assert.assertEquals(
 			workflowDefinition.getWorkflowDefinitionId(),
 			workflowMetricsSLADefinitionVersion.getProcessId());
 		Assert.assertEquals(
-			getInitialNodeKey(workflowDefinition, "2.0"),
+			getInitialNodeKey(workflowDefinition, "2"),
 			workflowMetricsSLADefinitionVersion.getStartNodeKeys());
 		Assert.assertEquals(
-			getTerminalNodeKey(workflowDefinition, "2.0"),
+			getTerminalNodeKey(workflowDefinition, "2"),
 			workflowMetricsSLADefinitionVersion.getStopNodeKeys());
 	}
 
@@ -113,13 +113,13 @@ public class WorkflowMetricsSLADefinitionTransformerMessageListenerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsNodeType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1);
 		assertCount(
 			_processWorkflowMetricsIndexNameBuilder.getIndexName(
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "active", true, "companyId",
 			workflowDefinition.getCompanyId(), "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1);
 
 		WorkflowMetricsSLADefinition workflowMetricsSLADefinition =
 			_workflowMetricsSLADefinitionLocalService.
@@ -141,14 +141,14 @@ public class WorkflowMetricsSLADefinitionTransformerMessageListenerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "active", true, "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "2.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 2);
 		assertCount(
 			4,
 			_nodeWorkflowMetricsIndexNameBuilder.getIndexName(
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsNodeType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "2.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 2);
 
 		_workflowMetricsSLADefinitionTransformerMessageListener.receive(
 			new Message());
@@ -159,7 +159,7 @@ public class WorkflowMetricsSLADefinitionTransformerMessageListenerTest
 					getWorkflowMetricsSLADefinitionVersion(
 						workflowMetricsSLADefinition.
 							getWorkflowMetricsSLADefinitionId(),
-						"2.0");
+						"2");
 
 		Assert.assertEquals(
 			workflowDefinition.getWorkflowDefinitionId(),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/InstanceWorkflowMetricsIndexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/InstanceWorkflowMetricsIndexerTest.java
@@ -56,7 +56,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", false,
 			"deleted", false, "instanceId", kaleoInstance.getKaleoInstanceId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"version", "1.0");
+			"version", 1);
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", false,
 			"deleted", false, "instanceId", kaleoInstance.getKaleoInstanceId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"version", "1.0");
+			"version", 1);
 
 		kaleoInstance = completeKaleoInstance(kaleoInstance);
 
@@ -90,7 +90,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", true,
 			"deleted", false, "duration", duration.toMillis(), "instanceId",
 			kaleoInstance.getKaleoInstanceId(), "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1);
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", false,
 			"deleted", true, "instanceId", kaleoInstance.getKaleoInstanceId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"version", "1.0");
+			"version", 1);
 	}
 
 	@Test
@@ -142,7 +142,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", false,
 			"deleted", false, "instanceId", kaleoInstance.getKaleoInstanceId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"version", "1.0");
+			"version", 1);
 
 		User user = UserTestUtil.addUser(
 			RandomTestUtil.randomString(
@@ -167,7 +167,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", false,
 			"deleted", false, "instanceId", kaleoInstance.getKaleoInstanceId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"version", "1.0");
+			"version", 1);
 
 		user.setMiddleName(RandomTestUtil.randomString());
 
@@ -187,7 +187,7 @@ public class InstanceWorkflowMetricsIndexerTest
 			"companyId", kaleoInstance.getCompanyId(), "completed", false,
 			"deleted", false, "instanceId", kaleoInstance.getKaleoInstanceId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"version", "1.0");
+			"version", 1);
 	}
 
 	@Inject(filter = "workflow.metrics.index.entity.name=instance")

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/NodeWorkflowMetricsIndexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/NodeWorkflowMetricsIndexerTest.java
@@ -57,8 +57,7 @@ public class NodeWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "deleted", false, "initial",
 			true, "name", "start", "nodeId", kaleoNode.getKaleoNodeId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"terminal", false, "type", NodeType.STATE.toString(), "version",
-			"1.0");
+			"terminal", false, "type", NodeType.STATE.toString(), "version", 1);
 
 		kaleoNode = addKaleoNode(new State("end", StringPool.BLANK, false));
 
@@ -69,8 +68,7 @@ public class NodeWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "deleted", false, "initial",
 			false, "name", "end", "nodeId", kaleoNode.getKaleoNodeId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"terminal", true, "type", NodeType.STATE.toString(), "version",
-			"1.0");
+			"terminal", true, "type", NodeType.STATE.toString(), "version", 1);
 	}
 
 	@Test
@@ -88,8 +86,7 @@ public class NodeWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "deleted", false, "initial",
 			false, "name", "review", "nodeId", kaleoTask.getKaleoTaskId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"terminal", false, "type", NodeType.TASK.toString(), "version",
-			"1.0");
+			"terminal", false, "type", NodeType.TASK.toString(), "version", 1);
 		assertCount(
 			_slaTaskResultWorkflowMetricsIndexNameBuilder.getIndexName(
 				workflowDefinition.getCompanyId()),
@@ -106,7 +103,7 @@ public class NodeWorkflowMetricsIndexerTest
 			false, "instanceId", 0, "processId",
 			workflowDefinition.getWorkflowDefinitionId(), "nodeId",
 			kaleoTask.getKaleoTaskId(), "name", "review", "taskId", 0,
-			"version", "1.0");
+			"version", 1);
 	}
 
 	@Test
@@ -121,8 +118,7 @@ public class NodeWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "deleted", false, "initial",
 			false, "name", "end", "nodeId", kaleoNode.getKaleoNodeId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"terminal", true, "type", NodeType.STATE.toString(), "version",
-			"1.0");
+			"terminal", true, "type", NodeType.STATE.toString(), "version", 1);
 
 		deleteKaleoNode(kaleoNode);
 
@@ -133,8 +129,7 @@ public class NodeWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "deleted", true, "initial",
 			false, "name", "end", "nodeId", kaleoNode.getKaleoNodeId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"terminal", true, "type", NodeType.STATE.toString(), "version",
-			"1.0");
+			"terminal", true, "type", NodeType.STATE.toString(), "version", 1);
 	}
 
 	@Test
@@ -154,8 +149,7 @@ public class NodeWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "deleted", true, "initial",
 			false, "name", "review", "nodeId", kaleoTask.getKaleoTaskId(),
 			"processId", workflowDefinition.getWorkflowDefinitionId(),
-			"terminal", false, "type", NodeType.TASK.toString(), "version",
-			"1.0");
+			"terminal", false, "type", NodeType.TASK.toString(), "version", 1);
 	}
 
 	@Test

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/ProcessWorkflowMetricsIndexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/ProcessWorkflowMetricsIndexerTest.java
@@ -46,8 +46,8 @@ public class ProcessWorkflowMetricsIndexerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0",
-			"versions", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1,
+			"versions", "1");
 		assertCount(
 			_instanceWorkflowMetricsIndexNameBuilder.getIndexName(
 				workflowDefinition.getCompanyId()),
@@ -73,7 +73,7 @@ public class ProcessWorkflowMetricsIndexerTest
 		assertCount(
 			_processWorkflowMetricsIndexNameBuilder.getIndexName(companyId),
 			"WorkflowMetricsProcessType", "companyId", companyId, "deleted",
-			true, "processId", workflowDefinitionId, "version", "1.0");
+			true, "processId", workflowDefinitionId, "version", 1);
 	}
 
 	@Test
@@ -102,7 +102,7 @@ public class ProcessWorkflowMetricsIndexerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "1.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 1);
 
 		updateWorkflowDefinition();
 
@@ -110,7 +110,7 @@ public class ProcessWorkflowMetricsIndexerTest
 			booleanQuery -> {
 				TermsQuery termsQuery = queries.terms("versions");
 
-				termsQuery.addValues("1.0", "2.0");
+				termsQuery.addValues("1", "2");
 
 				booleanQuery.addMustQueryClauses(termsQuery);
 			},
@@ -119,7 +119,7 @@ public class ProcessWorkflowMetricsIndexerTest
 				workflowDefinition.getCompanyId()),
 			"WorkflowMetricsProcessType", "companyId",
 			workflowDefinition.getCompanyId(), "deleted", false, "processId",
-			workflowDefinition.getWorkflowDefinitionId(), "version", "2.0");
+			workflowDefinition.getWorkflowDefinitionId(), "version", 2);
 	}
 
 	@Inject(filter = "workflow.metrics.index.entity.name=instance")

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/TaskWorkflowMetricsIndexerTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/internal/search/index/test/TaskWorkflowMetricsIndexerTest.java
@@ -49,7 +49,7 @@ public class TaskWorkflowMetricsIndexerTest
 			false, "processId", workflowDefinition.getWorkflowDefinitionId(),
 			"nodeId", kaleoTaskInstanceToken.getKaleoTaskId(), "name", "review",
 			"taskId", kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(),
-			"version", "1.0");
+			"version", 1);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class TaskWorkflowMetricsIndexerTest
 			false, "processId", workflowDefinition.getWorkflowDefinitionId(),
 			"nodeId", kaleoTaskInstanceToken.getKaleoTaskId(), "name", "review",
 			"taskId", kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(),
-			"version", "1.0");
+			"version", 1);
 
 		kaleoTaskInstanceToken = assignKaleoTaskInstanceToken(
 			kaleoTaskInstanceToken);
@@ -94,7 +94,7 @@ public class TaskWorkflowMetricsIndexerTest
 			false, "processId", workflowDefinition.getWorkflowDefinitionId(),
 			"nodeId", kaleoTaskInstanceToken.getKaleoTaskId(), "name", "review",
 			"taskId", kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(),
-			"version", "1.0");
+			"version", 1);
 
 		kaleoTaskInstanceToken = completeKaleoTaskInstanceToken(
 			kaleoTaskInstanceToken);
@@ -133,7 +133,7 @@ public class TaskWorkflowMetricsIndexerTest
 			true, "processId", workflowDefinition.getWorkflowDefinitionId(),
 			"nodeId", kaleoTaskInstanceToken.getKaleoTaskId(), "name", "review",
 			"taskId", kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(),
-			"version", "1.0");
+			"version", 1);
 	}
 
 	@Test
@@ -150,8 +150,7 @@ public class TaskWorkflowMetricsIndexerTest
 			workflowDefinition.getCompanyId(), "completed", false, "processId",
 			workflowDefinition.getWorkflowDefinitionId(), "nodeId",
 			kaleoTaskInstanceToken.getKaleoTaskId(), "name", "review", "taskId",
-			kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(), "version",
-			"1.0");
+			kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId(), "version", 1);
 	}
 
 	@Inject(filter = "workflow.metrics.index.entity.name=task")

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_3_x/UpgradeAssetVocabulary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_3_x/UpgradeAssetVocabulary.java
@@ -27,7 +27,7 @@ public class UpgradeAssetVocabulary extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		alter(
 			AssetVocabularyTable.class,
-			new AlterTableAddColumn("visibilityType", "INT"));
+			new AlterTableAddColumn("visibilityType", "INTEGER"));
 
 		runSQL(
 			"update AssetVocabulary set visibilityType = " +


### PR DESCRIPTION
**[LPS-107816](https://issues.liferay.com/browse/LPS-107816)**

**Previous pull requests**: https://github.com/achaparro/liferay-portal/pull/894 > https://github.com/achaparro/liferay-portal/pull/896 > https://github.com/achaparro/liferay-portal/pull/902

> This changes the type of the version column in KaleoDefinitionVersion from a String to an int.

**Changelog**:

**Upgrading from 6.2**
In the current implementation in `master`, `KaleoDefinitionVersion` only accounts for entries from the `KaleoDefinition` table. In order to include the missing draft versions, [additional entries need to be processed from the `KaleoDraftDefinition` table as well](https://github.com/achaparro/liferay-portal/blob/a62954d024e1f80c21f71e478deec540da9e4013/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/KaleoDefinitionVersionUpgradeProcess.java#L197-L198).

**Handling Decimal-Style Versions**
This addresses [an issue](https://github.com/liferay-workflow/liferay-portal/pull/375#issuecomment-848197114) in which `KaleoDefinitionVersion.version` is stored in a decimal-style format, e.g., "1.1", "2.3", etc. To resolve this, [all of the entries are first sorted by their name, then by the length of their versions, and then by their decimal value in ascending order](https://github.com/achaparro/liferay-portal/blob/a62954d024e1f80c21f71e478deec540da9e4013/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v4_0_0/UpgradeKaleoDefinitionVersion.java#L37-L38). Doing so prevents a situation in which, for example, "2.10" (length of 4) would appear before "2.2" (length of 3).

The sorted `KaleoDefinitionVersion` entries are then remapped to a new version number and the corresponding entries in `KaleoDefinition` are updated. Example:
|Before|After|
|---|---|
|1.0|1|
|1.1|2|
|1.2|3|
|2.0|4|

This solution makes the following assumptions:
1. Entries in `KaleoDefinitionVersion` can have either integer-style or decimal-style versions, but never both at the same time. For example, there cannot be an entry with version "1" and another entry with version "1.3." There can, however, be an entry with version "1.0" and another entry with version "1.3."
2. The largest possible version number is "99.99" (see `cast(version as decimal(4, 2))` in the `ORDER BY` clause of the sort)

**Known Issue**
After upgrading, entries in the `KaleoDefinition` table are all consolidated into a single entry. For example, continuing off of the previous before/after table:
|Before|After (Expected)|After (Actual)|
|---|---|---|
|KD entry version 1<br/>KD entry version 2|KD entry version 1<br/>KD entry version 4|KD entry version 4|