### PR TITLE
LPS-132020

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup/build.gradle
+++ b/modules/apps/data-cleanup/data-cleanup/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.8.LIFERAY-PATCHED-4"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -15,7 +15,6 @@
 package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.data.cleanup.internal.configuration.DataCleanupConfiguration;
-import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -159,9 +158,6 @@ public class DataCleanup implements UpgradeStepRegistrator {
 
 	@Reference
 	private ImageLocalService _imageLocalService;
-
-	@Reference
-	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Reference
 	private MBThreadLocalService _mbThreadLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -25,10 +25,15 @@ import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
+import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
+
+import org.apache.felix.cm.PersistenceManager;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -90,9 +95,11 @@ public class DataCleanup implements UpgradeStepRegistrator {
 			_cleanUpModuleData(
 				_dataCleanupConfiguration::cleanUpTwitterModuleData,
 				"com.liferay.twitter.service", TwitterUpgradeProcess::new);
+
+			_resetConfiguration();
 		}
-		catch (UpgradeException upgradeException) {
-			ReflectionUtil.throwException(upgradeException);
+		catch (Exception exception) {
+			ReflectionUtil.throwException(exception);
 		}
 	}
 
@@ -121,6 +128,33 @@ public class DataCleanup implements UpgradeStepRegistrator {
 		}
 	}
 
+	private void _resetConfiguration() throws Exception {
+		String pid = DataCleanupConfiguration.class.getName();
+
+		if (!_persistenceManager.exists(pid)) {
+			return;
+		}
+
+		Dictionary<?, ?> properties = _persistenceManager.load(pid);
+
+		Dictionary<String, Object> newProperties = new HashMapDictionary<>();
+
+		Enumeration<?> enumeration = properties.keys();
+
+		while (enumeration.hasMoreElements()) {
+			String key = (String)enumeration.nextElement();
+
+			if (key.startsWith("cleanUp")) {
+				newProperties.put(key, false);
+			}
+			else {
+				newProperties.put(key, properties.get(key));
+			}
+		}
+
+		_persistenceManager.store(pid, newProperties);
+	}
+
 	private DataCleanupConfiguration _dataCleanupConfiguration;
 
 	@Reference
@@ -131,6 +165,9 @@ public class DataCleanup implements UpgradeStepRegistrator {
 
 	@Reference
 	private MBThreadLocalService _mbThreadLocalService;
+
+	@Reference
+	private PersistenceManager _persistenceManager;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -104,6 +103,15 @@ public class DataCleanup implements UpgradeStepRegistrator {
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
+		if (_defaultProperties.size() < properties.size()) {
+			for (Map.Entry<String, Object> entry : properties.entrySet()) {
+				String key = entry.getKey();
+
+				_defaultProperties.put(
+					key, key.startsWith("cleanUp") ? false : entry.getValue());
+			}
+		}
+
 		_dataCleanupConfiguration = ConfigurableUtil.createConfigurable(
 			DataCleanupConfiguration.class, properties);
 	}
@@ -128,33 +136,13 @@ public class DataCleanup implements UpgradeStepRegistrator {
 	}
 
 	private void _resetConfiguration() throws Exception {
-		String pid = DataCleanupConfiguration.class.getName();
-
-		if (!_persistenceManager.exists(pid)) {
-			return;
-		}
-
-		Dictionary<?, ?> properties = _persistenceManager.load(pid);
-
-		Dictionary<String, Object> newProperties = new HashMapDictionary<>();
-
-		Enumeration<?> enumeration = properties.keys();
-
-		while (enumeration.hasMoreElements()) {
-			String key = (String)enumeration.nextElement();
-
-			if (key.startsWith("cleanUp")) {
-				newProperties.put(key, false);
-			}
-			else {
-				newProperties.put(key, properties.get(key));
-			}
-		}
-
-		_persistenceManager.store(pid, newProperties);
+		_persistenceManager.store(
+			DataCleanupConfiguration.class.getName(), _defaultProperties);
 	}
 
 	private DataCleanupConfiguration _dataCleanupConfiguration;
+	private final Dictionary<String, Object> _defaultProperties =
+		new HashMapDictionary<>();
 
 	@Reference
 	private ImageLocalService _imageLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -64,6 +63,15 @@ public class DataRemoval implements UpgradeStepRegistrator {
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
+		if (_defaultProperties.size() < properties.size()) {
+			for (Map.Entry<String, Object> entry : properties.entrySet()) {
+				String key = entry.getKey();
+
+				_defaultProperties.put(
+					key, key.startsWith("remove") ? false : entry.getValue());
+			}
+		}
+
 		_dataRemovalConfiguration = ConfigurableUtil.createConfigurable(
 			DataRemovalConfiguration.class, properties);
 	}
@@ -88,33 +96,13 @@ public class DataRemoval implements UpgradeStepRegistrator {
 	}
 
 	private void _resetConfiguration() throws Exception {
-		String pid = DataRemovalConfiguration.class.getName();
-
-		if (!_persistenceManager.exists(pid)) {
-			return;
-		}
-
-		Dictionary<?, ?> properties = _persistenceManager.load(pid);
-
-		Dictionary<String, Object> newProperties = new HashMapDictionary<>();
-
-		Enumeration<?> enumeration = properties.keys();
-
-		while (enumeration.hasMoreElements()) {
-			String key = (String)enumeration.nextElement();
-
-			if (key.startsWith("remove")) {
-				newProperties.put(key, false);
-			}
-			else {
-				newProperties.put(key, properties.get(key));
-			}
-		}
-
-		_persistenceManager.store(pid, newProperties);
+		_persistenceManager.store(
+			DataRemovalConfiguration.class.getName(), _defaultProperties);
 	}
 
 	private DataRemovalConfiguration _dataRemovalConfiguration;
+	private final Dictionary<String, Object> _defaultProperties =
+		new HashMapDictionary<>();
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
@@ -23,10 +23,15 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
+import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
+
+import org.apache.felix.cm.PersistenceManager;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -49,9 +54,11 @@ public class DataRemoval implements UpgradeStepRegistrator {
 				"com.liferay.journal.service",
 				() -> new ExpiredJournalArticleUpgradeProcess(
 					_journalArticleLocalService));
+
+			_resetConfiguration();
 		}
-		catch (UpgradeException upgradeException) {
-			ReflectionUtil.throwException(upgradeException);
+		catch (Exception exception) {
+			ReflectionUtil.throwException(exception);
 		}
 	}
 
@@ -80,10 +87,40 @@ public class DataRemoval implements UpgradeStepRegistrator {
 		}
 	}
 
+	private void _resetConfiguration() throws Exception {
+		String pid = DataRemovalConfiguration.class.getName();
+
+		if (!_persistenceManager.exists(pid)) {
+			return;
+		}
+
+		Dictionary<?, ?> properties = _persistenceManager.load(pid);
+
+		Dictionary<String, Object> newProperties = new HashMapDictionary<>();
+
+		Enumeration<?> enumeration = properties.keys();
+
+		while (enumeration.hasMoreElements()) {
+			String key = (String)enumeration.nextElement();
+
+			if (key.startsWith("remove")) {
+				newProperties.put(key, false);
+			}
+			else {
+				newProperties.put(key, properties.get(key));
+			}
+		}
+
+		_persistenceManager.store(pid, newProperties);
+	}
+
 	private DataRemovalConfiguration _dataRemovalConfiguration;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference
+	private PersistenceManager _persistenceManager;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-132020>

**Notes:**
This implementation utilizes the `PersistenceManager` API, specifically `ConfigurationPersistenceManager`, to set the configuration values to `false` after the data clean-up and removal tasks are executed. Let me know if there's anything I need to add or modify.

As a note, deleting the configuration information using `PersistenceManager#delete(String pid)` is an alternative approach that works. However, it would change the behavior of how the `Data Cleanup` and `Data Removal` configuration values are written to their corresponding OSGi configuration files. At the moment, the default behavior is that the current configuration values would be written to the files prior to DXP shutting down. However, because the configuration information is being deleted, the files would not get written and the values prior to startup would be preserved. So, if a user were to restart the portal without editing the files, then the clean-up and removal tasks would be run again.

Based on the goal of [LPS-132020](https://issues.liferay.com/browse/LPS-132020), I think this is not the behavior we want. With the implementation I'm proposing, the configuration values in the files would be written to `false`. And so users would not have to worry about re-running the clean-up and removal tasks. Let me know if you think otherwise and I can send another pull request.