### PR TITLE
LPS-135580 add column length limitation to the v1_1_3 SamlSpIdpConnec…

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v1_1_3/util/SamlSpIdpConnectionTable.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v1_1_3/util/SamlSpIdpConnectionTable.java
@@ -38,7 +38,7 @@ public class SamlSpIdpConnectionTable {
 	public static final String TABLE_NAME = "SamlSpIdpConnection";
 
 	public static final String[] TABLE_SQL_ADD_INDEXES = {
-		"create index IX_61204DD on SamlSpIdpConnection (companyId, samlIdpEntityId)"
+		"create index IX_61204DD on SamlSpIdpConnection (companyId, samlIdpEntityId[$COLUMN_LENGTH:1024$])"
 	};
 
 	public static final String TABLE_SQL_CREATE =


### PR DESCRIPTION
Hi @achaparro, I believe this is what is causing the index failure for LPP-41815. When I attempted to regenerate the table with the buildUpgradeTable command there were a lot of changes not present in the original file, so I opted to just change the 1 line that I believe is causing the issue. All other instances of creating IX_61204DD already had the column length limitation put on it, so I added this to bring it in line with the rest.

I do not have steps to reproduce for this bug, so if you think we need those to commit this, let me know and we can discuss it tomorrow.