### PR TITLE
LPS-132020 Set Data Cleanup configuration values to false after execution

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup/build.gradle
+++ b/modules/apps/data-cleanup/data-cleanup/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
+	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.8.LIFERAY-PATCHED-4"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/ConfigurationPersistenceManagerUtil.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/ConfigurationPersistenceManagerUtil.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.cleanup.internal.upgrade;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import java.io.IOException;
+
+import java.lang.reflect.Method;
+
+import java.util.Dictionary;
+
+import org.apache.felix.cm.PersistenceManager;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Kevin Lee
+ */
+@Component(service = {})
+public class ConfigurationPersistenceManagerUtil {
+
+	public static void resetConfiguration(Class<?> clazz) throws IOException {
+		Dictionary<String, Object> properties = _persistenceManager.load(
+			clazz.getName());
+
+		if (properties == null) {
+			return;
+		}
+
+		Dictionary<String, Object> newProperties =
+			HashMapDictionaryBuilder.<String, Object>putAll(
+				properties
+			).build();
+
+		for (Method method : clazz.getMethods()) {
+			if (!method.isAnnotationPresent(Meta.AD.class)) {
+				continue;
+			}
+
+			Class<?> returnType = method.getReturnType();
+
+			if (!returnType.equals(Boolean.TYPE)) {
+				continue;
+			}
+
+			String key = method.getName();
+
+			if (properties.get(key) != null) {
+				newProperties.put(key, false);
+			}
+		}
+
+		_persistenceManager.store(clazz.getName(), newProperties);
+	}
+
+	@Reference(unbind = "-")
+	protected void setPersistenceManager(
+		PersistenceManager persistenceManager) {
+
+		_persistenceManager = persistenceManager;
+	}
+
+	private static PersistenceManager _persistenceManager;
+
+}

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -15,6 +15,7 @@
 package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.data.cleanup.internal.configuration.DataCleanupConfiguration;
+import com.liferay.data.cleanup.internal.upgrade.util.ConfigurationPersistenceManagerUtil;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -25,17 +25,10 @@ import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
-import java.io.IOException;
-
-import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
-
-import org.apache.felix.cm.PersistenceManager;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -53,7 +46,8 @@ public class DataCleanup implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		try {
-			_resetConfiguration();
+			ConfigurationPersistenceManagerUtil.resetConfiguration(
+				DataCleanupConfiguration.class);
 
 			_cleanUpModuleData(
 				_dataCleanupConfiguration::cleanUpChatModuleData,
@@ -134,29 +128,6 @@ public class DataCleanup implements UpgradeStepRegistrator {
 		}
 	}
 
-	private void _resetConfiguration() throws IOException {
-		Dictionary<String, Object> properties = _persistenceManager.load(
-			DataCleanupConfiguration.class.getName());
-
-		if (properties == null) {
-			return;
-		}
-
-		Dictionary<String, Object> dictionary = new HashMapDictionary<>();
-
-		for (Enumeration<String> enumeration = properties.keys();
-			 enumeration.hasMoreElements();) {
-
-			String key = enumeration.nextElement();
-
-			dictionary.put(
-				key, key.startsWith("cleanUp") ? false : properties.get(key));
-		}
-
-		_persistenceManager.store(
-			DataCleanupConfiguration.class.getName(), dictionary);
-	}
-
 	private DataCleanupConfiguration _dataCleanupConfiguration;
 
 	@Reference
@@ -167,9 +138,6 @@ public class DataCleanup implements UpgradeStepRegistrator {
 
 	@Reference
 	private MBThreadLocalService _mbThreadLocalService;
-
-	@Reference
-	private PersistenceManager _persistenceManager;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -25,10 +25,17 @@ import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
+import java.io.IOException;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
+
+import org.apache.felix.cm.PersistenceManager;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -46,6 +53,8 @@ public class DataCleanup implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		try {
+			_resetConfiguration();
+
 			_cleanUpModuleData(
 				_dataCleanupConfiguration::cleanUpChatModuleData,
 				"com.liferay.chat.service", ChatUpgradeProcess::new);
@@ -95,8 +104,8 @@ public class DataCleanup implements UpgradeStepRegistrator {
 				_dataCleanupConfiguration::cleanUpTwitterModuleData,
 				"com.liferay.twitter.service", TwitterUpgradeProcess::new);
 		}
-		catch (UpgradeException upgradeException) {
-			ReflectionUtil.throwException(upgradeException);
+		catch (Exception exception) {
+			ReflectionUtil.throwException(exception);
 		}
 	}
 
@@ -125,6 +134,29 @@ public class DataCleanup implements UpgradeStepRegistrator {
 		}
 	}
 
+	private void _resetConfiguration() throws IOException {
+		Dictionary<String, Object> properties = _persistenceManager.load(
+			DataCleanupConfiguration.class.getName());
+
+		if (properties == null) {
+			return;
+		}
+
+		Dictionary<String, Object> dictionary = new HashMapDictionary<>();
+
+		for (Enumeration<String> enumeration = properties.keys();
+			 enumeration.hasMoreElements();) {
+
+			String key = enumeration.nextElement();
+
+			dictionary.put(
+				key, key.startsWith("cleanUp") ? false : properties.get(key));
+		}
+
+		_persistenceManager.store(
+			DataCleanupConfiguration.class.getName(), dictionary);
+	}
+
 	private DataCleanupConfiguration _dataCleanupConfiguration;
 
 	@Reference
@@ -135,6 +167,9 @@ public class DataCleanup implements UpgradeStepRegistrator {
 
 	@Reference
 	private MBThreadLocalService _mbThreadLocalService;
+
+	@Reference
+	private PersistenceManager _persistenceManager;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
@@ -15,6 +15,7 @@
 package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.data.cleanup.internal.configuration.DataRemovalConfiguration;
+import com.liferay.data.cleanup.internal.upgrade.util.ConfigurationPersistenceManagerUtil;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataRemoval.java
@@ -23,17 +23,10 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
-import java.io.IOException;
-
-import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.Map;
 import java.util.function.Supplier;
-
-import org.apache.felix.cm.PersistenceManager;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -51,7 +44,8 @@ public class DataRemoval implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		try {
-			_resetConfiguration();
+			ConfigurationPersistenceManagerUtil.resetConfiguration(
+				DataRemovalConfiguration.class);
 
 			_removeModuleData(
 				_dataRemovalConfiguration::removeExpiredJournalArticles,
@@ -89,36 +83,10 @@ public class DataRemoval implements UpgradeStepRegistrator {
 		}
 	}
 
-	private void _resetConfiguration() throws IOException {
-		Dictionary<String, Object> properties = _persistenceManager.load(
-			DataRemovalConfiguration.class.getName());
-
-		if (properties == null) {
-			return;
-		}
-
-		Dictionary<String, Object> dictionary = new HashMapDictionary<>();
-
-		for (Enumeration<String> enumeration = properties.keys();
-			 enumeration.hasMoreElements();) {
-
-			String key = enumeration.nextElement();
-
-			dictionary.put(
-				key, key.startsWith("remove") ? false : properties.get(key));
-		}
-
-		_persistenceManager.store(
-			DataRemovalConfiguration.class.getName(), dictionary);
-	}
-
 	private DataRemovalConfiguration _dataRemovalConfiguration;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;
-
-	@Reference
-	private PersistenceManager _persistenceManager;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/util/ConfigurationPersistenceManagerUtil.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/util/ConfigurationPersistenceManagerUtil.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.data.cleanup.internal.upgrade;
+package com.liferay.data.cleanup.internal.upgrade.util;
 
 import aQute.bnd.annotation.metatype.Meta;
 


### PR DESCRIPTION
**Tickets:**
* <https://issues.liferay.com/browse/LPS-132020>

**Notes:**
Previous pull request: <https://github.com/achaparro/liferay-portal/pull/952>

This implementation utilizes the `PersistenceManager` API, specifically `ConfigurationPersistenceManager`, to set the configuration values to `false` after the data clean-up and removal tasks are executed. Let me know if there's anything I need to add or modify. I've created a utility component class (`ConfigurationPersistenceManagerUtil.java`) to reduce redundancy between `DataCleanup.java` and `DataRemoval.java`. However, if you think it should be removed, feel free to make modifications or even revert the latest two commits.

As a note, deleting the configuration information using `PersistenceManager#delete(String pid)` is an alternative approach that works. However, it would change the behavior of how the `Data Cleanup` and `Data Removal` configuration values are written to their corresponding OSGi configuration files. At the moment, the default behavior is that the current configuration values would be written to the files with each Data Cleanup/Removal execution. However, because the configuration information is being deleted, the files would not get written and the values prior to startup would be preserved. So, if a user were to restart the portal without editing the files, then the clean-up and removal tasks would be run again.

Based on the goal of [LPS-132020](https://issues.liferay.com/browse/LPS-132020), I think this is not the behavior we want. With the implementation I'm proposing, the configuration values in the files would be written to `false`. And so users would not have to worry about re-running the clean-up and removal tasks. Let me know if you think otherwise and I can send another pull request.