### PR TITLE
LPS-137162 Create a file for the upgrade report and add some base information

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/source-formatter-suppressions.xml
+++ b/modules/apps/portal/portal-upgrade-impl/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport\.java" />
+	</source-check>
+</suppressions>

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
@@ -118,6 +118,8 @@ public class UpgradeReportLogAppender implements Appender {
 	@Override
 	public void stop() {
 		if (_started) {
+			_upgradeReport.generateReport();
+
 			_upgradeReport = null;
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -14,7 +14,16 @@
 
 package com.liferay.portal.upgrade.internal.report;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+import java.io.IOException;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +52,43 @@ public class UpgradeReport {
 			loggerName, key -> new ArrayList<>());
 
 		warningMessages.add(message);
+	}
+
+	public void generateReport() {
+		File file = new File(PropsValues.LIFERAY_HOME, "upgrade_report.info");
+
+		try {
+			FileUtil.write(file, _getProperties());
+		}
+		catch (IOException ioException) {
+		}
+	}
+
+	private String _getProperties() {
+		StringBuffer sb = new StringBuffer(9);
+
+		String dlStore = PropsValues.DL_STORE_IMPL;
+
+		sb.append(PropsKeys.DL_STORE_IMPL + StringPool.EQUAL + dlStore);
+
+		sb.append(StringPool.NEW_LINE);
+
+		if (dlStore.contains("FileSystemStore")) {
+			sb.append(
+				"Please check your OSGi configuration files to ensure " +
+					"rootDir has been set properly");
+
+			sb.append(StringPool.NEW_LINE);
+		}
+
+		sb.append(
+			"locales.enabled=" + Arrays.toString(PropsValues.LOCALES_ENABLED));
+		sb.append(StringPool.NEW_LINE);
+		sb.append("locales=" + Arrays.toString(PropsValues.LOCALES));
+		sb.append(StringPool.NEW_LINE);
+		sb.append("liferay.home=" + PropsValues.LIFERAY_HOME);
+
+		return sb.toString();
 	}
 
 	private final Map<String, ArrayList<String>> _errorMessages =

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.upgrade.internal.report;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -71,10 +73,28 @@ public class UpgradeReport {
 		try {
 			FileUtil.write(file, _getLiferayVersions());
 
+			FileUtil.write(file, _getDialectInfo(), false, true);
+
 			FileUtil.write(file, _getProperties(), false, true);
 		}
 		catch (IOException ioException) {
 		}
+	}
+
+	private String _getDialectInfo() {
+		StringBuffer sb = new StringBuffer(7);
+
+		DB db = DBManagerUtil.getDB();
+
+		sb.append("Using ");
+		sb.append(db.getDBType());
+		sb.append(" version ");
+		sb.append(db.getMajorVersion());
+		sb.append(StringPool.PERIOD);
+		sb.append(db.getMinorVersion());
+		sb.append(StringPool.NEW_LINE);
+
+		return sb.toString();
 	}
 
 	private int _getInitialBuildNumber() {


### PR DESCRIPTION
Hi Alberto,

I wanted to send this as a first pull request to set up the other parts of the report easier. I plan to just add method calls like these lines https://github.com/achaparro/liferay-portal/pull/980/files#diff-0cc31e20c7435b0bb5a700efbf64e8728d1867e4216fd2d8f616df6fe619d0dcR74-R78

As for the properties we are listing here, adding more as we believe them necessary should be very easy. Another option may be to just print the contents of the portal-upgrade-ext.properties. Let me know which option you believe would be the best.

Regarding getting the initial version of the database prior to upgrading, we should do this before the upgrade starts, when the logAppender is created and store that information. Otherwise we will not be able to retrieve it later.