### PR TITLE
LPS-137225 concurrentUpgrade()

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
@@ -116,7 +116,7 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 						"defaultLanguageId from JournalArticle");
 			ResultSet resultSet = selectPreparedStatement.executeQuery()) {
 
-			concurrentUpgrade(
+			processConcurrently(
 				() -> {
 					if (resultSet.next()) {
 						return new Object[] {
@@ -262,7 +262,7 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 
 			Map<Long, Locale> defaultSiteLocales = new HashMap<>();
 
-			concurrentUpgrade(
+			processConcurrently(
 				() -> {
 					if (resultSet.next()) {
 						String columnValue = resultSet.getString(3);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
@@ -135,7 +135,7 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 
 					return null;
 				},
-				BaseUpgradeCallable::call);
+				UpdateJournalArticleLocalizedFieldsUpgradeCallable::doCall);
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
@@ -124,37 +124,18 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 					"defaultLanguageId from JournalArticle");
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
-			List<UpdateJournalArticleLocalizedFieldsUpgradeCallable>
-				updateJournalArticleLocalizedFieldsUpgradeCallables =
-					new ArrayList<>();
-
-			while (resultSet.next()) {
-				UpdateJournalArticleLocalizedFieldsUpgradeCallable
-					updateJournalArticleLocalizedFieldsUpgradeCallable =
-						new UpdateJournalArticleLocalizedFieldsUpgradeCallable(
+			concurrentUpgrade(
+				() -> {
+					if (resultSet.next()) {
+						return new UpdateJournalArticleLocalizedFieldsUpgradeCallable(
 							resultSet.getLong(1), resultSet.getLong(2),
 							resultSet.getString(3), resultSet.getString(4),
 							resultSet.getString(5), sb.toString());
+					}
 
-				updateJournalArticleLocalizedFieldsUpgradeCallables.add(
-					updateJournalArticleLocalizedFieldsUpgradeCallable);
-			}
-
-			ExecutorService executorService = Executors.newWorkStealingPool();
-
-			List<Future<Boolean>> futures = executorService.invokeAll(
-				updateJournalArticleLocalizedFieldsUpgradeCallables);
-
-			executorService.shutdown();
-
-			for (Future<Boolean> future : futures) {
-				boolean success = GetterUtil.get(future.get(), true);
-
-				if (!success) {
-					throw new UpgradeException(
-						"Unable to update journal article localized fields");
-				}
-			}
+					return null;
+				},
+				BaseUpgradeCallable::call);
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
@@ -20,10 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.upgrade.BaseUpgradeCallable;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -36,16 +33,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 /**
  * @author Jürgen Kappler
@@ -268,51 +260,52 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 					"defaultLanguageId = ''"));
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
-			List<UpdateDefaultLanguageUpgradeCallable>
-				updateDefaultLanguageCallables = new ArrayList<>();
+			Map<Long, Locale> defaultSiteLocales = new HashMap<>();
 
-			while (resultSet.next()) {
-				String columnValue = resultSet.getString(3);
+			concurrentUpgrade(
+				() -> {
+					if (resultSet.next()) {
+						String columnValue = resultSet.getString(3);
 
-				if (Validator.isXml(columnValue) || strictUpdate) {
-					long groupId = resultSet.getLong(2);
+						if (Validator.isXml(columnValue) || strictUpdate) {
+							long groupId = resultSet.getLong(2);
 
-					Locale defaultSiteLocale = _defaultSiteLocales.get(groupId);
+							Locale defaultSiteLocale = defaultSiteLocales.get(
+								groupId);
 
-					if (defaultSiteLocale == null) {
-						defaultSiteLocale = PortalUtil.getSiteDefaultLocale(
-							groupId);
+							if (defaultSiteLocale == null) {
+								defaultSiteLocale =
+									PortalUtil.getSiteDefaultLocale(groupId);
 
-						_defaultSiteLocales.put(groupId, defaultSiteLocale);
+								defaultSiteLocales.put(
+									groupId, defaultSiteLocale);
+							}
+
+							return new Object[] {
+								resultSet.getLong(1), columnValue,
+								defaultSiteLocale
+							};
+						}
 					}
 
-					UpdateDefaultLanguageUpgradeCallable
-						updateDefaultLanguageCallable =
-							new UpdateDefaultLanguageUpgradeCallable(
-								resultSet.getLong(1), columnValue,
-								defaultSiteLocale);
+					return null;
+				},
+				values -> {
+					long id = (Long)values[0];
 
-					updateDefaultLanguageCallables.add(
-						updateDefaultLanguageCallable);
-				}
-			}
+					String xml = (String)values[1];
+					Locale defaultSiteLocale = (Locale)values[2];
 
-			ExecutorService executorService = Executors.newWorkStealingPool();
+					String defaultLanguageId =
+						LocalizationUtil.getDefaultLanguageId(
+							xml, defaultSiteLocale);
 
-			List<Future<Boolean>> futures = executorService.invokeAll(
-				updateDefaultLanguageCallables);
-
-			executorService.shutdown();
-
-			for (Future<Boolean> future : futures) {
-				boolean success = GetterUtil.get(future.get(), true);
-
-				if (!success) {
-					throw new UpgradeException(
-						"Unable to update journal article default language " +
-							"IDs");
-				}
-			}
+					runSQL(
+						connection,
+						StringBundler.concat(
+							"update JournalArticle set defaultLanguageId = '",
+							defaultLanguageId, "' where id_ = ", id));
+				});
 		}
 	}
 
@@ -324,49 +317,5 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 		JournalArticleLocalizedValuesUpgradeProcess.class);
 
 	private final CounterLocalService _counterLocalService;
-	private final Map<Long, Locale> _defaultSiteLocales = new HashMap<>();
-
-	private class UpdateDefaultLanguageUpgradeCallable
-		extends BaseUpgradeCallable<Boolean> {
-
-		public UpdateDefaultLanguageUpgradeCallable(
-			long id, String xml, Locale defaultSiteLocale) {
-
-			_id = id;
-
-			_xml = xml;
-
-			_defaultLanguageId = LocalizationUtil.getDefaultLanguageId(
-				_xml, defaultSiteLocale);
-		}
-
-		@Override
-		protected Boolean doCall() throws Exception {
-			try {
-				StringBundler sb = new StringBundler(4);
-
-				sb.append("update JournalArticle set defaultLanguageId = '");
-				sb.append(_defaultLanguageId);
-				sb.append("' where id_ = ");
-				sb.append(_id);
-
-				runSQL(connection, sb.toString());
-			}
-			catch (Exception exception) {
-				_log.error(
-					"Unable to update default language ID for article " + _id,
-					exception);
-
-				return false;
-			}
-
-			return true;
-		}
-
-		private final String _defaultLanguageId;
-		private final long _id;
-		private final String _xml;
-
-	}
 
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
@@ -112,30 +112,97 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 	}
 
 	protected void updateJournalArticleLocalizedFields() throws Exception {
-		StringBundler sb = new StringBundler(3);
-
-		sb.append("insert into JournalArticleLocalization(");
-		sb.append("articleLocalizationId, companyId, articlePK, title, ");
-		sb.append("description, languageId) values(?, ?, ?, ?, ?, ?)");
+		String sql =
+			"insert into JournalArticleLocalization(articleLocalizationId, " +
+				"companyId, articlePK, title, description, languageId) " +
+					"values(?, ?, ?, ?, ?, ?)";
 
 		try (LoggingTimer loggingTimer = new LoggingTimer();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select id_, companyId, title, description, " +
-					"defaultLanguageId from JournalArticle");
-			ResultSet resultSet = preparedStatement.executeQuery()) {
+			PreparedStatement selectPreparedStatement =
+				connection.prepareStatement(
+					"select id_, companyId, title, description, " +
+						"defaultLanguageId from JournalArticle");
+			ResultSet resultSet = selectPreparedStatement.executeQuery()) {
 
 			concurrentUpgrade(
 				() -> {
 					if (resultSet.next()) {
-						return new UpdateJournalArticleLocalizedFieldsUpgradeCallable(
+						return new Object[] {
 							resultSet.getLong(1), resultSet.getLong(2),
 							resultSet.getString(3), resultSet.getString(4),
-							resultSet.getString(5), sb.toString());
+							resultSet.getString(5)
+						};
 					}
 
 					return null;
 				},
-				UpdateJournalArticleLocalizedFieldsUpgradeCallable::doCall);
+				values -> {
+					long id = (Long)values[0];
+					long companyId = (Long)values[1];
+
+					String title = (String)values[2];
+					String description = (String)values[3];
+					String defaultLanguageId = (String)values[4];
+
+					Map<Locale, String> titleMap = _getLocalizationMap(
+						title, defaultLanguageId);
+					Map<Locale, String> descriptionMap = _getLocalizationMap(
+						description, defaultLanguageId);
+
+					Set<Locale> locales = new HashSet<>();
+
+					locales.addAll(titleMap.keySet());
+					locales.addAll(descriptionMap.keySet());
+
+					try (PreparedStatement updatePreparedStatement =
+							AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+								connection, sql)) {
+
+						for (Locale locale : locales) {
+							String localizedTitle = titleMap.get(locale);
+							String localizedDescription = descriptionMap.get(
+								locale);
+
+							if ((localizedTitle != null) &&
+								(localizedTitle.length() > _MAX_LENGTH_TITLE)) {
+
+								localizedTitle = StringUtil.shorten(
+									localizedTitle, _MAX_LENGTH_TITLE);
+
+								_log(id, "title");
+							}
+
+							if (localizedDescription != null) {
+								String safeLocalizedDescription = _truncate(
+									localizedDescription,
+									_MAX_LENGTH_DESCRIPTION);
+
+								if (localizedDescription !=
+										safeLocalizedDescription) {
+
+									_log(id, "description");
+								}
+
+								localizedDescription = safeLocalizedDescription;
+							}
+
+							updatePreparedStatement.setLong(
+								1, _counterLocalService.increment());
+							updatePreparedStatement.setLong(2, companyId);
+							updatePreparedStatement.setLong(3, id);
+							updatePreparedStatement.setString(
+								4, localizedTitle);
+							updatePreparedStatement.setString(
+								5, localizedDescription);
+							updatePreparedStatement.setString(
+								6, LocaleUtil.toLanguageId(locale));
+
+							updatePreparedStatement.addBatch();
+						}
+
+						updatePreparedStatement.executeBatch();
+					}
+				});
 		}
 	}
 
@@ -299,98 +366,6 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 		private final String _defaultLanguageId;
 		private final long _id;
 		private final String _xml;
-
-	}
-
-	private class UpdateJournalArticleLocalizedFieldsUpgradeCallable
-		extends BaseUpgradeCallable<Boolean> {
-
-		public UpdateJournalArticleLocalizedFieldsUpgradeCallable(
-				long id, long companyId, String title, String description,
-				String defaultLanguageId, String sql)
-			throws Exception {
-
-			_id = id;
-			_companyId = companyId;
-			_title = title;
-			_description = description;
-			_defaultLanguageId = defaultLanguageId;
-			_sql = sql;
-		}
-
-		@Override
-		protected Boolean doCall() throws Exception {
-			Map<Locale, String> titleMap = _getLocalizationMap(
-				_title, _defaultLanguageId);
-			Map<Locale, String> descriptionMap = _getLocalizationMap(
-				_description, _defaultLanguageId);
-
-			Set<Locale> locales = new HashSet<>();
-
-			locales.addAll(titleMap.keySet());
-			locales.addAll(descriptionMap.keySet());
-
-			try (PreparedStatement preparedStatement =
-					AutoBatchPreparedStatementUtil.concurrentAutoBatch(
-						connection, _sql)) {
-
-				for (Locale locale : locales) {
-					String localizedTitle = titleMap.get(locale);
-					String localizedDescription = descriptionMap.get(locale);
-
-					if ((localizedTitle != null) &&
-						(localizedTitle.length() > _MAX_LENGTH_TITLE)) {
-
-						localizedTitle = StringUtil.shorten(
-							localizedTitle, _MAX_LENGTH_TITLE);
-
-						_log(_id, "title");
-					}
-
-					if (localizedDescription != null) {
-						String safeLocalizedDescription = _truncate(
-							localizedDescription, _MAX_LENGTH_DESCRIPTION);
-
-						if (localizedDescription != safeLocalizedDescription) {
-							_log(_id, "description");
-						}
-
-						localizedDescription = safeLocalizedDescription;
-					}
-
-					preparedStatement.setLong(
-						1, _counterLocalService.increment());
-					preparedStatement.setLong(2, _companyId);
-					preparedStatement.setLong(3, _id);
-					preparedStatement.setString(4, localizedTitle);
-					preparedStatement.setString(5, localizedDescription);
-					preparedStatement.setString(
-						6, LocaleUtil.toLanguageId(locale));
-
-					preparedStatement.addBatch();
-				}
-
-				try {
-					preparedStatement.executeBatch();
-				}
-				catch (Exception exception) {
-					_log.error(
-						"Unable to update localized fields for article " + _id,
-						exception);
-
-					return false;
-				}
-			}
-
-			return true;
-		}
-
-		private final long _companyId;
-		private final String _defaultLanguageId;
-		private final String _description;
-		private final long _id;
-		private final String _sql;
-		private final String _title;
 
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -59,7 +59,7 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 					"JournalArticle where ctCollectionId = 0");
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
-			concurrentUpgrade(
+			processConcurrently(
 				() -> {
 					if (resultSet.next()) {
 						return new JournalArticleInfo(

--- a/portal-impl/src/com/liferay/portal/verify/VerifyUUID.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyUUID.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.upgrade.BaseUpgradeCallable;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.verify.model.VerifiableUUIDModel;
@@ -29,10 +28,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Brian Wing Shun Chan
@@ -61,17 +59,19 @@ public class VerifyUUID extends VerifyProcess {
 	protected void doVerify(VerifiableUUIDModel... verifiableUUIDModels)
 		throws Exception {
 
-		List<VerifyUUIDUpgradeCallable> verifyUUIDUpgradeCallables =
-			new ArrayList<>(verifiableUUIDModels.length);
+		AtomicInteger atomicInteger = new AtomicInteger();
 
-		for (VerifiableUUIDModel verifiableUUIDModel : verifiableUUIDModels) {
-			VerifyUUIDUpgradeCallable verifyUUIDUpgradeCallable =
-				new VerifyUUIDUpgradeCallable(verifiableUUIDModel);
+		processConcurrently(
+			() -> {
+				int index = atomicInteger.getAndIncrement();
 
-			verifyUUIDUpgradeCallables.add(verifyUUIDUpgradeCallable);
-		}
+				if (index < verifiableUUIDModels.length) {
+					return verifiableUUIDModels[index];
+				}
 
-		doVerify(verifyUUIDUpgradeCallables);
+				return null;
+			},
+			this::verifyUUID);
 	}
 
 	protected void verifyUUID(VerifiableUUIDModel verifiableUUIDModel)
@@ -129,25 +129,6 @@ public class VerifyUUID extends VerifyProcess {
 
 			preparedStatement2.executeBatch();
 		}
-	}
-
-	private class VerifyUUIDUpgradeCallable extends BaseUpgradeCallable<Void> {
-
-		@Override
-		protected Void doCall() throws Exception {
-			verifyUUID(_verifiableUUIDModel);
-
-			return null;
-		}
-
-		private VerifyUUIDUpgradeCallable(
-			VerifiableUUIDModel verifiableUUIDModel) {
-
-			_verifiableUUIDModel = verifiableUUIDModel;
-		}
-
-		private final VerifiableUUIDModel _verifiableUUIDModel;
-
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -15,9 +15,6 @@
 package com.liferay.portal.kernel.upgrade;
 
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
-import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.petra.function.UnsafeSupplier;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -32,8 +29,6 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.module.framework.ThrowableCollector;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.util.UpgradeColumn;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTable;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTableFactoryUtil;
@@ -65,11 +60,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -333,56 +324,6 @@ public abstract class UpgradeProcess
 
 		private final String _columnName;
 
-	}
-
-	protected static <T> void concurrentUpgrade(
-			UnsafeSupplier<T, Exception> unsafeSupplier,
-			UnsafeConsumer<T, Exception> unsafeConsumer)
-		throws Exception {
-
-		Objects.requireNonNull(unsafeSupplier);
-		Objects.requireNonNull(unsafeConsumer);
-
-		ExecutorService executorService = Executors.newWorkStealingPool();
-
-		ThrowableCollector throwableCollector = new ThrowableCollector();
-
-		List<Future<Void>> futures = new ArrayList<>();
-
-		try {
-			long companyId = CompanyThreadLocal.getCompanyId();
-
-			T next = null;
-
-			while ((next = unsafeSupplier.get()) != null) {
-				T current = next;
-
-				Future<Void> future = executorService.submit(
-					() -> {
-						try (SafeCloseable safeCloseable =
-								CompanyThreadLocal.lock(companyId)) {
-
-							unsafeConsumer.accept(current);
-						}
-						catch (Exception exception) {
-							throwableCollector.collect(exception);
-						}
-
-						return null;
-					});
-
-				futures.add(future);
-			}
-		}
-		finally {
-			executorService.shutdown();
-
-			for (Future<Void> future : futures) {
-				future.get();
-			}
-		}
-
-		throwableCollector.rethrow();
 	}
 
 	protected void alter(Class<?> tableClass, Alterable... alterables)

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -336,11 +335,10 @@ public abstract class UpgradeProcess
 
 	}
 
-	protected static <T, E1 extends Exception, E2 extends Exception> void
-			concurrentUpgrade(
-				UnsafeSupplier<T, E1> unsafeSupplier,
-				UnsafeConsumer<T, E2> unsafeConsumer)
-		throws E1, E2 {
+	protected static <T> void concurrentUpgrade(
+			UnsafeSupplier<T, Exception> unsafeSupplier,
+			UnsafeConsumer<T, Exception> unsafeConsumer)
+		throws Exception {
 
 		Objects.requireNonNull(unsafeSupplier);
 		Objects.requireNonNull(unsafeConsumer);
@@ -366,6 +364,9 @@ public abstract class UpgradeProcess
 
 							unsafeConsumer.accept(current);
 						}
+						catch (Exception exception) {
+							throwableCollector.collect(exception);
+						}
 
 						return null;
 					});
@@ -377,15 +378,7 @@ public abstract class UpgradeProcess
 			executorService.shutdown();
 
 			for (Future<Void> future : futures) {
-				try {
-					future.get();
-				}
-				catch (ExecutionException executionException) {
-					throwableCollector.collect(executionException.getCause());
-				}
-				catch (Exception exception) {
-					throwableCollector.collect(exception);
-				}
+				future.get();
 			}
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.kernel.upgrade;
 
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -29,6 +31,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.framework.ThrowableCollector;
 import com.liferay.portal.kernel.upgrade.util.UpgradeColumn;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTable;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTableFactoryUtil;
@@ -60,7 +63,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -324,6 +332,56 @@ public abstract class UpgradeProcess
 
 		private final String _columnName;
 
+	}
+
+	protected static <T, E1 extends Exception, E2 extends Exception> void
+			concurrentUpgrade(
+				UnsafeSupplier<T, E1> unsafeSupplier,
+				UnsafeConsumer<T, E2> unsafeConsumer)
+		throws E1, E2 {
+
+		Objects.requireNonNull(unsafeSupplier);
+		Objects.requireNonNull(unsafeConsumer);
+
+		ExecutorService executorService = Executors.newWorkStealingPool();
+
+		ThrowableCollector throwableCollector = new ThrowableCollector();
+
+		List<Future<Void>> futures = new ArrayList<>();
+
+		try {
+			T next = null;
+
+			while ((next = unsafeSupplier.get()) != null) {
+				T current = next;
+
+				Future<Void> future = executorService.submit(
+					() -> {
+						unsafeConsumer.accept(current);
+
+						return null;
+					});
+
+				futures.add(future);
+			}
+		}
+		finally {
+			executorService.shutdown();
+
+			for (Future<Void> future : futures) {
+				try {
+					future.get();
+				}
+				catch (ExecutionException executionException) {
+					throwableCollector.collect(executionException.getCause());
+				}
+				catch (Exception exception) {
+					throwableCollector.collect(exception);
+				}
+			}
+		}
+
+		throwableCollector.rethrow();
 	}
 
 	protected void alter(Class<?> tableClass, Alterable... alterables)

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.upgrade;
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.util.UpgradeColumn;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTable;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTableFactoryUtil;
@@ -350,6 +352,8 @@ public abstract class UpgradeProcess
 		List<Future<Void>> futures = new ArrayList<>();
 
 		try {
+			long companyId = CompanyThreadLocal.getCompanyId();
+
 			T next = null;
 
 			while ((next = unsafeSupplier.get()) != null) {
@@ -357,7 +361,11 @@ public abstract class UpgradeProcess
 
 				Future<Void> future = executorService.submit(
 					() -> {
-						unsafeConsumer.accept(current);
+						try (SafeCloseable safeCloseable =
+								CompanyThreadLocal.lock(companyId)) {
+
+							unsafeConsumer.accept(current);
+						}
 
 						return null;
 					});

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -104,6 +104,7 @@
 		<suppress checks="JavaVariableTypeCheck" files="portal-impl/test/unit/com/liferay/portal/json/Two\.java" />
 		<suppress checks="JavaVariableTypeCheck" files="portal-kernel/src/com/liferay/portal/kernel/io/PathHolder\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-impl/src/com/liferay/portal/upgrade/util/BaseUpgradeTableImpl.java" />
+		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-impl/src/com/liferay/portal/verify/VerifyUUID\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="portal-impl/src/com/liferay/portal/security/xml/SecureXMLFactoryProviderImpl\.java" />


### PR DESCRIPTION
If this looks good please send it to @shuyangzhou so he can review the executor part, not sure if `Executors.newWorkStealingPool()` is the best option for this use case.

Also not sure if we can or should add a way to share a PreparedStatement among several tasks in the same thread or if it's possible to run into thread safety problems if we create PreparedStatements from a single Connection in separate threads like we're already doing in JournalArticleLocalizedValuesUpgradeProcess.

Thanks!