### PR TITLE
LPS-86764 Useless upgrade processes run during the initial database creation

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/AnnouncementsWebUpgrade.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/AnnouncementsWebUpgrade.java
@@ -16,9 +16,7 @@ package com.liferay.announcements.web.internal.upgrade;
 
 import com.liferay.announcements.web.internal.upgrade.v1_0_2.PermissionUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -31,32 +29,6 @@ public class AnnouncementsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease upgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.announcements.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {
-						"com_liferay_announcements_web_portlet_AlertsPortlet",
-						"com_liferay_announcements_web_portlet_" +
-							"AnnouncementsPortlet"
-					};
-				}
-
-			};
-
-		try {
-			upgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "2.0.0", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.1", new DummyUpgradeStep());

--- a/modules/apps/asset/asset-publisher-layout-prototype/src/main/java/com/liferay/asset/publisher/layout/prototype/internal/upgrade/AssetPublisherLayoutPrototypeUpgrade.java
+++ b/modules/apps/asset/asset-publisher-layout-prototype/src/main/java/com/liferay/asset/publisher/layout/prototype/internal/upgrade/AssetPublisherLayoutPrototypeUpgrade.java
@@ -29,7 +29,7 @@ public class AssetPublisherLayoutPrototypeUpgrade
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("1.0.0", "1.0.1", new UpgradeLocalizedColumn());
 	}

--- a/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/upgrade/BlogsLayoutPrototypeUpgrade.java
+++ b/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/upgrade/BlogsLayoutPrototypeUpgrade.java
@@ -28,7 +28,7 @@ public class BlogsLayoutPrototypeUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("1.0.0", "1.0.1", new UpgradeLocalizedColumn());
 	}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/upgrade/BlogsWebUpgrade.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/upgrade/BlogsWebUpgrade.java
@@ -36,7 +36,7 @@ public class BlogsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.2.1", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0", new UpgradePortletPreferences(),

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/upgrade/CalendarWebUpgrade.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/upgrade/CalendarWebUpgrade.java
@@ -41,7 +41,7 @@ public class CalendarWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.1.2", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
 

--- a/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/CaptchaUpgrade.java
+++ b/modules/apps/captcha/captcha-impl/src/main/java/com/liferay/captcha/internal/upgrade/CaptchaUpgrade.java
@@ -32,7 +32,7 @@ public class CaptchaUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "0.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.1.0", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/upgrade/PublicationsWebUpgrade.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/upgrade/PublicationsWebUpgrade.java
@@ -36,7 +36,7 @@ public class PublicationsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.2", new DummyUpgradeStep());
 
 		registry.register(
 			"1.0.0", "1.0.1",

--- a/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/upgrade/ContactsWebUpgrade.java
+++ b/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/upgrade/ContactsWebUpgrade.java
@@ -28,7 +28,7 @@ public class ContactsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.1", new UpgradePortletId());
 

--- a/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/upgrade/DocumentConversionUpgrade.java
+++ b/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/upgrade/DocumentConversionUpgrade.java
@@ -30,7 +30,7 @@ public class DocumentConversionUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "0.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/document-library/document-library-layout-set-prototype/src/main/java/com/liferay/document/library/layout/set/prototype/internal/upgrade/DocumentLibraryLayoutSetPrototypeUpgrade.java
+++ b/modules/apps/document-library/document-library-layout-set-prototype/src/main/java/com/liferay/document/library/layout/set/prototype/internal/upgrade/DocumentLibraryLayoutSetPrototypeUpgrade.java
@@ -29,7 +29,7 @@ public class DocumentLibraryLayoutSetPrototypeUpgrade
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("1.0.0", "1.0.1", new UpgradeLocalizedColumn());
 	}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/upgrade/ExportImportServiceUpgrade.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/upgrade/ExportImportServiceUpgrade.java
@@ -40,7 +40,7 @@ public class ExportImportServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.2", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/upgrade/KnowledgeBaseWebUpgrade.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/upgrade/KnowledgeBaseWebUpgrade.java
@@ -20,9 +20,7 @@ import com.liferay.knowledge.base.web.internal.upgrade.v1_1_0.UpgradePortletPref
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -36,34 +34,6 @@ public class KnowledgeBaseWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease upgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.knowledge.base.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {
-						"1_WAR_knowledgebaseportlet",
-						"2_WAR_knowledgebaseportlet",
-						"3_WAR_knowledgebaseportlet",
-						"4_WAR_knowledgebaseportlet",
-						"5_WAR_knowledgebaseportlet"
-					};
-				}
-
-			};
-
-		try {
-			upgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/upgrade/KnowledgeBaseWebUpgrade.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/upgrade/KnowledgeBaseWebUpgrade.java
@@ -34,7 +34,7 @@ public class KnowledgeBaseWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.2.0", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0", new UpgradePortletId(),

--- a/modules/apps/license-manager/license-manager-web/src/main/java/com/liferay/license/manager/web/internal/upgrade/LicenseManagerWebUpgrade.java
+++ b/modules/apps/license-manager/license-manager-web/src/main/java/com/liferay/license/manager/web/internal/upgrade/LicenseManagerWebUpgrade.java
@@ -27,7 +27,7 @@ public class LicenseManagerWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/message-boards/message-boards-layout-set-prototype/src/main/java/com/liferay/message/boards/layout/set/prototype/internal/upgrade/MessageBoardsLayoutSetPrototypeUpgrade.java
+++ b/modules/apps/message-boards/message-boards-layout-set-prototype/src/main/java/com/liferay/message/boards/layout/set/prototype/internal/upgrade/MessageBoardsLayoutSetPrototypeUpgrade.java
@@ -29,7 +29,7 @@ public class MessageBoardsLayoutSetPrototypeUpgrade
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("1.0.0", "1.0.1", new UpgradeLocalizedColumn());
 	}

--- a/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/upgrade/MicroblogsWebUpgrade.java
+++ b/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/upgrade/MicroblogsWebUpgrade.java
@@ -16,9 +16,7 @@ package com.liferay.microblogs.web.internal.upgrade;
 
 import com.liferay.microblogs.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -31,30 +29,6 @@ public class MicroblogsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease baseUpgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.microblogs.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {
-						"1_WAR_microblogsportlet", "2_WAR_microblogsportlet"
-					};
-				}
-
-			};
-
-		try {
-			baseUpgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.1", new UpgradePortletId());

--- a/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/upgrade/MicroblogsWebUpgrade.java
+++ b/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/upgrade/MicroblogsWebUpgrade.java
@@ -29,7 +29,7 @@ public class MicroblogsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.1", new UpgradePortletId());
 

--- a/modules/apps/my-subscriptions/my-subscriptions-web/src/main/java/com/liferay/my/subscriptions/web/internal/upgrade/MySubscriptionsWebUpgrade.java
+++ b/modules/apps/my-subscriptions/my-subscriptions-web/src/main/java/com/liferay/my/subscriptions/web/internal/upgrade/MySubscriptionsWebUpgrade.java
@@ -17,9 +17,7 @@ package com.liferay.my.subscriptions.web.internal.upgrade;
 import com.liferay.my.subscriptions.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -34,28 +32,6 @@ public class MySubscriptionsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease upgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.my.subscriptions.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {"1_WAR_mysubscriptionsportlet"};
-				}
-
-			};
-
-		try {
-			upgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/NotificationsWebUpgrade.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/NotificationsWebUpgrade.java
@@ -18,10 +18,8 @@ import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.upgrade.BaseReplacePortletId;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,31 +33,6 @@ public class NotificationsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease baseUpgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.notifications.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {
-						"1_WAR_notificationsportlet",
-						"2_WAR_notificationsportlet"
-					};
-				}
-
-			};
-
-		try {
-			baseUpgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "2.1.0", new DummyUpgradeStep());
 
 		registry.register(

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/upgrade/OrganizationServiceUpgrade.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/upgrade/OrganizationServiceUpgrade.java
@@ -33,7 +33,7 @@ public class OrganizationServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "0.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/upgrade/SearchWebUpgrade.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/upgrade/SearchWebUpgrade.java
@@ -30,7 +30,7 @@ public class SearchWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "2.0.0", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0", new UpgradePortletId(),

--- a/modules/apps/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/internal/upgrade/PortalSettingWebUpgrade.java
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/internal/upgrade/PortalSettingWebUpgrade.java
@@ -30,7 +30,7 @@ public class PortalSettingWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.2", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
 

--- a/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/upgrade/UploadUpgrade.java
+++ b/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/upgrade/UploadUpgrade.java
@@ -30,7 +30,7 @@ public class UploadUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "0.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/upgrade/SiteNavigationMenuWebUpgrade.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/upgrade/SiteNavigationMenuWebUpgrade.java
@@ -30,7 +30,7 @@ public class SiteNavigationMenuWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0", new UpgradePortletId(),

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/upgrade/UsersAdminWebUpgrade.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/upgrade/UsersAdminWebUpgrade.java
@@ -43,7 +43,7 @@ public class UsersAdminWebUpgrade implements UpgradeStepRegistrator {
 			_releaseLocalService.updateRelease(release);
 		}
 
-		registry.register("0.0.0", "0.0.1", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register(
 			"0.0.1", "1.0.0",

--- a/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/upgrade/WikiLayoutPrototypeUpgrade.java
+++ b/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/upgrade/WikiLayoutPrototypeUpgrade.java
@@ -28,7 +28,7 @@ public class WikiLayoutPrototypeUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("1.0.0", "1.0.1", new UpgradeLocalizedColumn());
 	}

--- a/modules/apps/wiki/wiki-navigation-web/src/main/java/com/liferay/wiki/navigation/web/internal/upgrade/WikiNavigationWebUpgrade.java
+++ b/modules/apps/wiki/wiki-navigation-web/src/main/java/com/liferay/wiki/navigation/web/internal/upgrade/WikiNavigationWebUpgrade.java
@@ -16,9 +16,7 @@ package com.liferay.wiki.navigation.web.internal.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 import com.liferay.wiki.navigation.web.internal.upgrade.v1_0_0.UpgradePortletPreferences;
 import com.liferay.wiki.navigation.web.internal.upgrade.v1_0_1.UpgradePortletId;
 
@@ -33,31 +31,6 @@ public class WikiNavigationWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease upgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.wiki.navigation.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {
-						"1_WAR_wikinavigationportlet",
-						"2_WAR_wikinavigationportlet"
-					};
-				}
-
-			};
-
-		try {
-			upgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "1.0.1", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletPreferences());

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/upgrade/ReportsWebUpgrade.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/upgrade/ReportsWebUpgrade.java
@@ -16,10 +16,8 @@ package com.liferay.portal.reports.engine.console.web.internal.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.reports.engine.console.web.internal.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,30 +30,6 @@ public class ReportsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeWebModuleRelease upgradeWebModuleRelease =
-			new BaseUpgradeWebModuleRelease() {
-
-				@Override
-				protected String getBundleSymbolicName() {
-					return "com.liferay.portal.reports.engine.console.web";
-				}
-
-				@Override
-				protected String[] getPortletIds() {
-					return new String[] {
-						"1_WAR_reportsportlet", "2_WAR_reportsportlet"
-					};
-				}
-
-			};
-
-		try {
-			upgradeWebModuleRelease.upgrade();
-		}
-		catch (UpgradeException upgradeException) {
-			throw new RuntimeException(upgradeException);
-		}
-
 		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/upgrade/KaleoDesignerWebUpgrade.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/upgrade/KaleoDesignerWebUpgrade.java
@@ -36,7 +36,7 @@ public class KaleoDesignerWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.2", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.0", new UpgradePortletId());
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/upgrade/KaleoFormsWebUpgrade.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/java/com/liferay/portal/workflow/kaleo/forms/web/internal/upgrade/KaleoFormsWebUpgrade.java
@@ -29,7 +29,7 @@ public class KaleoFormsWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.2", new DummyUpgradeStep());
+		registry.register("0.0.0", "1.0.3", new DummyUpgradeStep());
 
 		registry.register("0.0.1", "1.0.2", new UpgradePortletId());
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeModules.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeModules.java
@@ -148,12 +148,14 @@ public class UpgradeModules extends UpgradeProcess {
 		"com.liferay.invitation.web", "com.liferay.item.selector.web",
 		"com.liferay.journal.content.search.web",
 		"com.liferay.journal.content.web", "com.liferay.journal.service",
-		"com.liferay.journal.web", "com.liferay.layout.admin.web",
-		"com.liferay.license.manager.web", "com.liferay.loan.calculator.web",
-		"com.liferay.login.web", "com.liferay.message.boards.web",
+		"com.liferay.journal.web", "com.liferay.knowledge.base.web",
+		"com.liferay.layout.admin.web", "com.liferay.license.manager.web",
+		"com.liferay.loan.calculator.web", "com.liferay.login.web",
+		"com.liferay.message.boards.web",
 		"com.liferay.mobile.device.rules.service",
 		"com.liferay.mobile.device.rules.web", "com.liferay.my.account.web",
-		"com.liferay.nested.portlets.web", "com.liferay.network.utilities.web",
+		"com.liferay.my.subscriptions.web", "com.liferay.nested.portlets.web",
+		"com.liferay.network.utilities.web",
 		"com.liferay.password.generator.web", "com.liferay.plugins.admin.web",
 		"com.liferay.polls.service",
 		"com.liferay.portal.background.task.service",
@@ -179,8 +181,8 @@ public class UpgradeModules extends UpgradeProcess {
 		"com.liferay.softwarecatalog.service", "com.liferay.staging.bar.web",
 		"com.liferay.translator.web", "com.liferay.trash.web",
 		"com.liferay.unit.converter.web", "com.liferay.web.proxy.web",
-		"com.liferay.wiki.service", "com.liferay.wiki.web",
-		"com.liferay.xsl.content.web"
+		"com.liferay.wiki.navigation.web", "com.liferay.wiki.service",
+		"com.liferay.wiki.web", "com.liferay.xsl.content.web"
 	};
 
 	private static final String[][] _CONVERTED_LEGACY_MODULES = {


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-86764>

**Notes:**
After looking at the startup logs and diving into the code, these are the modules where unnecessary upgrades are being run:

```log
com.liferay.asset.publisher.layout.prototype.internal.upgrade
com.liferay.blogs.layout.prototype.internal.upgrade
com.liferay.blogs.web.internal.upgrade
com.liferay.calendar.web.internal.upgrade
com.liferay.captcha.internal.upgrade
com.liferay.change.tracking.web.internal.upgrade
com.liferay.contacts.web.internal.upgrade
com.liferay.document.library.document.conversion.internal.upgrade
com.liferay.document.library.layout.set.prototype.internal.upgrade
com.liferay.exportimport.internal.upgrade
com.liferay.knowledge.base.web.internal.upgrade
com.liferay.license.manager.web.internal.upgrade
com.liferay.message.boards.layout.set.prototype.internal.upgrade
com.liferay.microblogs.web.internal.upgrade
com.liferay.organizations.internal.upgrade
com.liferay.portal.search.web.internal.upgrade
com.liferay.portal.settings.web.internal.upgrade
com.liferay.portal.upload.internal.upgrade
com.liferay.portal.workflow.kaleo.designer.web.internal.upgrade
com.liferay.portal.workflow.kaleo.forms.web.internal.upgrade
com.liferay.site.navigation.menu.web.internal.upgrade
com.liferay.users.admin.web.internal.upgrade
com.liferay.wiki.layout.prototype.internal.upgrade
```

In the future, we should implement some way (perhaps a SF rule) to check upgrade paths for modules and prevent situations like this. Let me know if I need to change/modify anything. Also, please take your time reviewing these changes as many files/upgrades are being changed.