### PR TITLE
Lps 138030

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/build.gradle
+++ b/modules/apps/portal/portal-upgrade-impl/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.14.1.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "commons-io", name: "commons-io", version: "2.8.0"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.upgrade.internal.apache.logging.log4j.core;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.upgrade.internal.report.UpgradeReport;
 
 import java.io.Serializable;
@@ -115,7 +116,8 @@ public class UpgradeReportLogAppender implements Appender {
 	public void start() {
 		_started = true;
 
-		_upgradeReport = new UpgradeReport(_persistenceManager);
+		_upgradeReport = new UpgradeReport(
+			_persistenceManager, _releaseManagerOSGiCommands);
 
 		_rootLogger.addAppender(this);
 	}
@@ -136,6 +138,9 @@ public class UpgradeReportLogAppender implements Appender {
 
 	@Reference
 	private PersistenceManager _persistenceManager;
+
+	@Reference
+	private ReleaseManagerOSGiCommands _releaseManagerOSGiCommands;
 
 	private volatile boolean _started;
 	private volatile UpgradeReport _upgradeReport;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
@@ -52,11 +52,14 @@ public class UpgradeReportLogAppender implements Appender {
 				logEvent.getLoggerName(), message.getFormattedMessage());
 		}
 		else if (logEvent.getLevel() == Level.INFO) {
+			String formattedMessage = message.getFormattedMessage();
+
 			if (Objects.equals(
-					logEvent.getLoggerName(), UpgradeProcess.class.getName())) {
+					logEvent.getLoggerName(), UpgradeProcess.class.getName()) &&
+				formattedMessage.startsWith("Completed upgrade process ")) {
 
 				_upgradeReport.addEventMessage(
-					logEvent.getLoggerName(), message.getFormattedMessage());
+					logEvent.getLoggerName(), formattedMessage);
 			}
 		}
 		else if (logEvent.getLevel() == Level.WARN) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
@@ -68,6 +68,11 @@ public class ReleaseManagerOSGiCommands {
 		return _check(true);
 	}
 
+	@Descriptor("List pending upgrade processes and their upgrade steps")
+	public String checkAll(boolean showUpgradeSteps) {
+		return _check(showUpgradeSteps);
+	}
+
 	@Descriptor("Execute upgrade for a specific module")
 	public String execute(String bundleSymbolicName) {
 		List<UpgradeInfo> upgradeInfos = _releaseManagerImpl.getUpgradeInfos(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/osgi/commands/ReleaseManagerOSGiCommands.java
@@ -301,6 +301,8 @@ public class ReleaseManagerOSGiCommands {
 							upgradeInfo.getToSchemaVersionString()));
 				}
 			}
+
+			sb.append(StringPool.NEW_LINE);
 		}
 
 		return sb.toString();

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -502,6 +502,10 @@ public class UpgradeReport {
 
 			String className = entry.substring(startIndex, endIndex);
 
+			if (className.equals(PortalUpgradeProcess.class.getName())) {
+				continue;
+			}
+
 			startIndex = entry.indexOf(StringPool.SPACE, endIndex + 1);
 
 			endIndex = entry.indexOf(StringPool.SPACE, startIndex + 1);

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -80,7 +80,7 @@ public class UpgradeReport {
 		Map<String, Integer> errorMessages = _errorMessages.computeIfAbsent(
 			loggerName, key -> new ConcurrentHashMap<>());
 
-		int occurrences = errorMessages.computeIfAbsent(message, key -> 1);
+		int occurrences = errorMessages.computeIfAbsent(message, key -> 0);
 
 		occurrences++;
 
@@ -98,7 +98,7 @@ public class UpgradeReport {
 		Map<String, Integer> warningMessages = _warningMessages.computeIfAbsent(
 			loggerName, key -> new ConcurrentHashMap<>());
 
-		int occurrences = warningMessages.computeIfAbsent(message, key -> 1);
+		int occurrences = warningMessages.computeIfAbsent(message, key -> 0);
 
 		occurrences++;
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -246,7 +246,7 @@ public class UpgradeReport {
 				dictionary[index]);
 
 			return StringBundler.concat(
-				"The Document Library is ", size, StringPool.NEW_LINE);
+				"The Document Library size is ", size, StringPool.NEW_LINE);
 		}
 
 		return "Please check the size of the Liferay Document Library in " +

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -108,7 +108,8 @@ public class UpgradeReport {
 				_getReportFile(),
 				StringBundler.concat(
 					_getPortalVersions(), _getDialectInfo(), _getProperties(),
-					_getDocLibSize(), _getLogEvents("errors")));
+					_getDocLibSize(), _getLogEvents("errors"),
+					_getLogEvents("warnings")));
 		}
 		catch (IOException ioException) {
 			_log.error("Unable to generate the upgrade report");

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -496,7 +496,7 @@ public class UpgradeReport {
 		Map<String, Integer> upgradeProcessMap = new HashMap<>();
 
 		for (String entry : upgradeTimes) {
-			int startIndex = entry.indexOf("com");
+			int startIndex = entry.indexOf("com.");
 
 			int endIndex = entry.indexOf(StringPool.SPACE, startIndex);
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -111,8 +111,8 @@ public class UpgradeReport {
 				_getReportFile(),
 				StringBundler.concat(
 					_getPortalVersions(), _getDialectInfo(), _getProperties(),
-					_getDocLibSize(), _getUpgradeTimes(),
-					_getLogEvents("errors"), _getLogEvents("warnings")));
+					_getDLSize(), _getUpgradeTimes(), _getLogEvents("errors"),
+					_getLogEvents("warnings")));
 		}
 		catch (IOException ioException) {
 			_log.error("Unable to generate the upgrade report");
@@ -148,7 +148,7 @@ public class UpgradeReport {
 			StringPool.PERIOD, db.getMinorVersion(), StringPool.NEW_LINE);
 	}
 
-	private String _getDocLibSize() {
+	private String _getDLSize() {
 		if (_dlStore.equals("com.liferay.portal.store.db.DBStore")) {
 			return StringPool.BLANK;
 		}
@@ -165,16 +165,15 @@ public class UpgradeReport {
 
 			final AtomicLong length = new AtomicLong(0);
 
-			String docLibPath =
-				PropsValues.LIFERAY_HOME + "/data/document_library";
+			String dlPath = PropsValues.LIFERAY_HOME + "/data/document_library";
 
 			if (_rootDir != null) {
-				docLibPath = _rootDir + "/data/document_library";
+				dlPath = _rootDir + "/data/document_library";
 			}
 
 			try {
 				Files.walkFileTree(
-					Paths.get(docLibPath),
+					Paths.get(dlPath),
 					new SimpleFileVisitor<Path>() {
 
 						@Override

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -109,10 +109,13 @@ public class UpgradeReport {
 		try {
 			FileUtil.write(
 				_getReportFile(),
-				StringBundler.concat(
-					_getPortalVersions(), _getDialectInfo(), _getProperties(),
-					_getDLSize(), _getUpgradeTimes(), _getLogEvents("errors"),
-					_getLogEvents("warnings")));
+				StringUtil.merge(
+					new String[] {
+						_getPortalVersions(), _getDialectInfo(),
+						_getProperties(), _getDLSize(), _getUpgradeTimes(),
+						_getLogEvents("errors"), _getLogEvents("warnings")
+					},
+					StringPool.NEW_LINE + StringPool.NEW_LINE));
 		}
 		catch (IOException ioException) {
 			_log.error("Unable to generate the upgrade report");
@@ -145,7 +148,7 @@ public class UpgradeReport {
 
 		return StringBundler.concat(
 			"Using ", db.getDBType(), " version ", db.getMajorVersion(),
-			StringPool.PERIOD, db.getMinorVersion(), StringPool.NEW_LINE);
+			StringPool.PERIOD, db.getMinorVersion());
 	}
 
 	private String _getDLSize() {
@@ -245,8 +248,7 @@ public class UpgradeReport {
 				String.format("%." + 2 + "f", bytes), StringPool.SPACE,
 				dictionary[index]);
 
-			return StringBundler.concat(
-				"The Document Library size is ", size, StringPool.NEW_LINE);
+			return "The Document Library size is " + size;
 		}
 
 		return "Please check the size of the Liferay Document Library in " +
@@ -313,12 +315,11 @@ public class UpgradeReport {
 				sb.append(type);
 				sb.append(": ");
 				sb.append(valueEntry.getKey());
+				sb.append(StringPool.NEW_LINE);
 			}
 
 			sb.append(StringPool.NEW_LINE);
 		}
-
-		sb.append(StringPool.NEW_LINE);
 
 		return sb.toString();
 	}
@@ -335,8 +336,7 @@ public class UpgradeReport {
 			StringPool.NEW_LINE,
 			_getReleaseInfo(
 				ReleaseInfo.getBuildNumber(), latestSchemaVersion.toString(),
-				"expected"),
-			StringPool.NEW_LINE);
+				"expected"));
 	}
 
 	private String _getProperties() {
@@ -383,8 +383,6 @@ public class UpgradeReport {
 		if (_rootDir != null) {
 			sb.append("rootDir=" + _rootDir);
 		}
-
-		sb.append(StringPool.NEW_LINE);
 
 		return sb.toString();
 	}
@@ -488,7 +486,7 @@ public class UpgradeReport {
 			UpgradeProcess.class.getName());
 
 		if (_eventMessages.size() == 0) {
-			return "Unable to get upgrade process times\n\n";
+			return "Unable to get upgrade process times";
 		}
 
 		StringBundler sb = new StringBundler();
@@ -531,8 +529,6 @@ public class UpgradeReport {
 				break;
 			}
 		}
-
-		sb.append(StringPool.NEW_LINE);
 
 		return sb.toString();
 	}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -62,8 +63,12 @@ import org.apache.felix.cm.PersistenceManager;
  */
 public class UpgradeReport {
 
-	public UpgradeReport(PersistenceManager persistenceManager) {
+	public UpgradeReport(
+		PersistenceManager persistenceManager,
+		ReleaseManagerOSGiCommands releaseManagerOSGiCommands) {
+
 		_persistenceManager = persistenceManager;
+		_releaseManagerOSGiCommands = releaseManagerOSGiCommands;
 
 		_initialBuildNumber = _getBuildNumber();
 		_initialSchemaVersion = _getSchemaVersion();
@@ -106,7 +111,8 @@ public class UpgradeReport {
 					new String[] {
 						_getPortalVersions(), _getDialectInfo(),
 						_getProperties(), _getDLSize(), _getUpgradeTimes(),
-						_getLogEvents("errors"), _getLogEvents("warnings")
+						_getLogEvents("errors"), _getLogEvents("warnings"),
+						_getModuleUpgradeStatus()
 					},
 					StringPool.NEW_LINE + StringPool.NEW_LINE));
 		}
@@ -262,6 +268,10 @@ public class UpgradeReport {
 		}
 
 		return sb.toString();
+	}
+
+	private String _getModuleUpgradeStatus() {
+		return _releaseManagerOSGiCommands.checkAll(false);
 	}
 
 	private String _getPortalVersions() {
@@ -520,6 +530,7 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private final String _initialSchemaVersion;
 	private final PersistenceManager _persistenceManager;
+	private final ReleaseManagerOSGiCommands _releaseManagerOSGiCommands;
 	private String _rootDir;
 	private final Map<String, Map<String, Integer>> _warningMessages =
 		new ConcurrentHashMap<>();

--- a/modules/apps/portal/portal-upgrade-test/build.gradle
+++ b/modules/apps/portal/portal-upgrade-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.14.1.LIFERAY-PATCHED-1"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
@@ -17,9 +17,12 @@ package com.liferay.portal.upgrade.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
@@ -67,6 +70,43 @@ public class UpgradeReportLogAppenderTest {
 
 			reportsDir.delete();
 		}
+	}
+
+	@Test
+	public void testLogEvents() throws Exception {
+		_appender.start();
+
+		Log log = LogFactoryUtil.getLog(UpgradeReportLogAppenderTest.class);
+
+		log.warn("Warning");
+		log.warn("Warning");
+
+		log = LogFactoryUtil.getLog(UpgradeProcess.class);
+
+		log.info(
+			"Completed upgrade process " +
+				"com.liferay.portal.upgrade.PortalUpgradeProcess in 20401 ms");
+
+		_appender.stop();
+
+		_testReport("2 occurrences of the following warnings: Warning");
+
+		_testReport(
+			"com.liferay.portal.upgrade.PortalUpgradeProcess took 20401 ms " +
+				"to complete");
+	}
+
+	@Test
+	public void testNoLogEvents() throws Exception {
+		_appender.start();
+
+		_appender.stop();
+
+		_testReport("Unable to get upgrade process times");
+
+		_testReport("No errors thrown during upgrade.");
+
+		_testReport("No warnings thrown during upgrade.");
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
@@ -128,6 +128,33 @@ public class UpgradeReportLogAppenderTest {
 	}
 
 	@Test
+	public void testModuleUpgrades() throws Exception {
+		String bundleSymbolicName = "com.liferay.asset.service";
+
+		Release release = _releaseLocalService.fetchRelease(bundleSymbolicName);
+
+		String initialSchemaVersion = release.getSchemaVersion();
+
+		release.setSchemaVersion("0.0.1");
+
+		_releaseLocalService.updateRelease(release);
+
+		_appender.start();
+
+		_appender.stop();
+
+		release = _releaseLocalService.fetchRelease(bundleSymbolicName);
+
+		release.setSchemaVersion(initialSchemaVersion);
+
+		_releaseLocalService.updateRelease(release);
+
+		_assertReport(
+			"There are upgrade processes available for " +
+				"com.liferay.asset.service from 0.0.1 to 2.1.0");
+	}
+
+	@Test
 	public void testNoLogEvents() throws Exception {
 		_appender.start();
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
@@ -176,8 +176,8 @@ public class UpgradeReportLogAppenderTest {
 
 		release = _releaseLocalService.getRelease(1);
 
-		release.setBuildNumber(ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER);
 		release.setSchemaVersion("1.0.0");
+		release.setBuildNumber(ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER);
 
 		_releaseLocalService.updateRelease(release);
 
@@ -185,8 +185,8 @@ public class UpgradeReportLogAppenderTest {
 
 		release = _releaseLocalService.getRelease(1);
 
-		release.setBuildNumber(initialBuildNumber);
 		release.setSchemaVersion(initialSchemaVersion);
+		release.setBuildNumber(initialBuildNumber);
 
 		_releaseLocalService.updateRelease(release);
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.core.Appender;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Sam Ziemer
+ */
+@RunWith(Arquillian.class)
+public class UpgradeReportLogAppenderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@After
+	public void tearDown() {
+		File reportsDir = new File(".", "reports");
+
+		if ((reportsDir != null) && reportsDir.exists()) {
+			File reportFile = new File(reportsDir, "upgrade_report.info");
+
+			if (reportFile.exists()) {
+				reportFile.delete();
+			}
+
+			reportsDir.delete();
+		}
+	}
+
+	@Test
+	public void testProperties() throws Exception {
+		StringBuffer sb = new StringBuffer(15);
+
+		sb.append(PropsKeys.LIFERAY_HOME);
+		sb.append(StringPool.EQUAL);
+		sb.append(PropsValues.LIFERAY_HOME);
+		sb.append(StringPool.NEW_LINE);
+		sb.append(PropsKeys.LOCALES);
+		sb.append(StringPool.EQUAL);
+		sb.append(Arrays.toString(PropsValues.LOCALES));
+		sb.append(StringPool.NEW_LINE);
+		sb.append(PropsKeys.LOCALES_ENABLED);
+		sb.append(StringPool.EQUAL);
+		sb.append(Arrays.toString(PropsValues.LOCALES_ENABLED));
+		sb.append(StringPool.NEW_LINE);
+		sb.append(PropsKeys.DL_STORE_IMPL);
+		sb.append(StringPool.EQUAL);
+		sb.append(PropsValues.DL_STORE_IMPL);
+
+		_appender.start();
+
+		_appender.stop();
+
+		_testReport(sb.toString());
+	}
+
+	@Test
+	public void testSchemaVersion() throws Exception {
+		Release release = _releaseLocalService.getRelease(1);
+
+		int initialBuildNumber = release.getBuildNumber();
+		String initialSchemaVersion = release.getSchemaVersion();
+
+		release = _releaseLocalService.getRelease(1);
+
+		release.setBuildNumber(ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER);
+		release.setSchemaVersion("1.0.0");
+
+		_releaseLocalService.updateRelease(release);
+
+		_appender.start();
+
+		release = _releaseLocalService.getRelease(1);
+
+		release.setBuildNumber(initialBuildNumber);
+		release.setSchemaVersion(initialSchemaVersion);
+
+		_releaseLocalService.updateRelease(release);
+
+		_appender.stop();
+
+		Version latestSchemaVersion =
+			PortalUpgradeProcess.getLatestSchemaVersion();
+
+		String testString = StringBundler.concat(
+			"Initial portal build number: 7100\n",
+			"Initial portal schema version: 1.0.0\n",
+			"Final portal build number: ", ReleaseInfo.getBuildNumber(),
+			StringPool.NEW_LINE, "Final portal schema version: ",
+			latestSchemaVersion.toString(), StringPool.NEW_LINE,
+			"Expected portal build number: ", ReleaseInfo.getBuildNumber(),
+			StringPool.NEW_LINE, "Expected portal schema version: ",
+			latestSchemaVersion.toString(), StringPool.NEW_LINE);
+
+		_testReport(testString);
+	}
+
+	private void _testReport(String testString) throws Exception {
+		File reportsDir = new File(".", "reports");
+
+		Assert.assertTrue(reportsDir.exists());
+
+		File reportFile = new File(reportsDir, "upgrade_report.info");
+
+		Assert.assertTrue(reportFile.exists());
+
+		String report = FileUtil.read(reportFile);
+
+		Assert.assertTrue(
+			StringUtil.contains(report, testString, StringPool.BLANK));
+	}
+
+	@Inject
+	private Appender _appender;
+
+	@Inject
+	private ReleaseLocalService _releaseLocalService;
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138030

Hey Alberto,

After looking into this issue and trying a few different routes, I think the cleanest option is to just print the list of pending upgrades retrieved from releaseManagerOSGiCommands. The list given by it only shows modules that have pending upgrades and portal upgrade processes that are pending. If everything has upgraded completely, then nothing is shown. I needed to make a minor change within releaseManagerOSGiCommands to be able to pass a showUpgradesSteps parameter so we only see the bundle symbolic name and its current schema version plus the highest available schema version.

We can discuss this issue more tomorrow if you think another approach would be best.