### PR TITLE
LPS-120292 Add dummy upgrade process to make 7.1.x backport possible

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.v7_1_x;
 
+import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.upgrade.util.PortalUpgradeProcessRegistry;
@@ -65,6 +66,8 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeProcesses.put(
 			new Version(2, 0, 8),
 			new UpgradeCalendarClassNameIdsPortletPreferences());
+
+		upgradeProcesses.put(new Version(2, 0, 9), new DummyUpgradeProcess());
 	}
 
 }


### PR DESCRIPTION
Hi @achaparro ,

This is an additional commit to make the backport of [LPS-120292](https://issues.liferay.com/browse/LPS-120292) to 7.1.x possible. Previous PR: https://github.com/achaparro/liferay-portal/pull/716 . For this, my plan is to:
* Create a dummy upgrade step in [v7_1_x/PortalUpgradeProcessRegistryImpl.java](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java): `Version(2, 0, 9)`. (This is the current PR).
* Backport this dummy step to 7.3.x and 7.2.x. However, there's a dependency: https://github.com/liferay/liferay-portal/commit/f93b24089a94bba90bf868452f638eb0e4c03399 is not backported yet to 7.3, 7.2 and 7.1. I'm working on it now ([7.3 backport PR](https://github.com/liferay/liferay-portal-ee/pull/25315)). We decided to backport these missing steps on [PTR-2556](https://issues.liferay.com/browse/PTR-2556).
* Add the real [LPS-120292](https://issues.liferay.com/browse/LPS-120292) upgrade step in 7.1.x branch, as `Version(2, 0, 9)`.

This is part of a bigger plan, since we would like to switch multiple columns to CLOB, these will be done on separate fixes:
* `Layout.description`: done by [LPS-120292](https://issues.liferay.com/browse/LPS-120292), backported until 7.2, need to backport it to 7.1
* `Layout.title`: will be done by [LPS-135254](https://issues.liferay.com/browse/LPS-135254)
* `AssetCategory.title` + `AssetCategory.description` by [LPS-135261](https://issues.liferay.com/browse/LPS-135261)

Please review my changes.

Thanks,
Vendel