### PR TITLE
LPS-143830 Upgrade does not properly handle partitioned databases

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
@@ -14,10 +14,14 @@
 
 package com.liferay.portal.upgrade;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.upgrade.util.PortalUpgradeProcessRegistry;
@@ -130,16 +134,35 @@ public class PortalUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	public void upgrade() throws UpgradeException {
+		long start = System.currentTimeMillis();
+
+		String message = "Completed upgrade process ";
+
 		try (Connection connection = getConnection()) {
 			this.connection = connection;
+
+			if (_log.isInfoEnabled()) {
+				String info = "Upgrading " + ClassUtil.getClassName(this);
+
+				_log.info(info);
+			}
 
 			doUpgrade();
 		}
 		catch (Exception exception) {
+			message = "Failed upgrade process ";
+
 			throw new UpgradeException(exception);
 		}
 		finally {
 			this.connection = null;
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						message, ClassUtil.getClassName(this), " in ",
+						System.currentTimeMillis() - start, " ms"));
+			}
 		}
 	}
 
@@ -203,6 +226,9 @@ public class PortalUpgradeProcess extends UpgradeProcess {
 			class,
 		com.liferay.portal.upgrade.v7_4_x.PortalUpgradeProcessRegistryImpl.class
 	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalUpgradeProcess.class);
 
 	private static final Version _initialSchemaVersion = new Version(0, 1, 0);
 	private static final TreeMap<Version, UpgradeProcess> _upgradeProcesses =

--- a/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade;
 
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.version.Version;
@@ -125,6 +126,21 @@ public class PortalUpgradeProcess extends UpgradeProcess {
 		}
 
 		return false;
+	}
+
+	@Override
+	public void upgrade() throws UpgradeException {
+		try (Connection connection = getConnection()) {
+			this.connection = connection;
+
+			doUpgrade();
+		}
+		catch (Exception exception) {
+			throw new UpgradeException(exception);
+		}
+		finally {
+			this.connection = null;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-143830>

__Notes:__
The issue is that `CompanyThreadLocal` is prematurely locked before the portal upgrade processes are run on the companies. This is happening because `PortalUpgradeProcess` itself is a `UpgradeProcess`, meaning `PortalUpgradeProcess` is run on each company via `DBPartitionUtil.forEachCompanyId()`, which locks `CompanyThreadLocal` before executing the upgrade subprocesses within it. See the following code:

- [UpgradeProcess.java#L109-L123](https://github.com/liferay/liferay-portal/blob/7.4.3.8-ga8/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java#L109-L123)
- [BaseDBProcess.java#L244](https://github.com/liferay/liferay-portal/blob/7.4.3.8-ga8/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java#L244)
- [BaseDB.java#L308](https://github.com/liferay/liferay-portal/blob/7.4.3.8-ga8/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java#L308)
- [DBPartitionUtil.java#L118-L130](https://github.com/liferay/liferay-portal/blob/7.4.3.8-ga8/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java#L118-L130)

We only need to execute the **upgrade processes in** `PortalUpgradeProcess` on each company. `PortalUpgradeProcess` only needs to be run once. We can achieve this by overriding `UpgradeProcess.upgrade()`. `PortalUpgradeProcess` should be the only exception where this overriding is necessary. Let me know if you have any questions/thoughts.

Thank you!