### PR TITLE
LPS-139342 Processing company IDs can be parallelized

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -152,6 +152,18 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	public void testForEachCompanyId() throws Exception {
 		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
 
+		ReflectionTestUtil.setFieldValue(
+			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
+			false);
+
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> Assert.assertEquals(
+				companyId, CompanyThreadLocal.getCompanyId()));
+
+		ReflectionTestUtil.setFieldValue(
+			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
+			true);
+
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> Assert.assertEquals(
 				companyId, CompanyThreadLocal.getCompanyId()));

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -165,6 +165,9 @@ public abstract class BaseDBPartitionTestCase {
 		ReflectionTestUtil.setFieldValue(
 			DBPartitionUtil.class, "_DATABASE_PARTITION_SCHEMA_NAME_PREFIX",
 			_DB_PARTITION_SCHEMA_NAME_PREFIX);
+		ReflectionTestUtil.setFieldValue(
+			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
+			true);
 
 		DBPartitionUtil.setDefaultCompanyId(portal.getDefaultCompanyId());
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -668,6 +668,10 @@ public class DBPartitionUtil {
 			PropsUtil.get("database.partition.schema.name.prefix"),
 			"lpartition_");
 
+	private static final boolean _DATABASE_PARTITION_THREAD_POOL_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get("database.partition.thread.pool.enabled"));
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DBPartitionUtil.class);
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -301,6 +301,9 @@ public class DBPartitionUtil {
 
 								unsafeConsumer.accept(companyId);
 							}
+							catch (Exception exception) {
+								throwableCollector.collect(exception);
+							}
 
 							return null;
 						});

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portal.db.partition;
 
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.dao.jdbc.util.ConnectionWrapper;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.module.framework.ThrowableCollector;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -52,6 +54,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import javax.sql.DataSource;
 
@@ -117,6 +122,12 @@ public class DBPartitionUtil {
 
 		if (CompanyThreadLocal.isLocked()) {
 			unsafeConsumer.accept(CompanyThreadLocal.getCompanyId());
+
+			return;
+		}
+
+		if (_DATABASE_PARTITION_THREAD_POOL_ENABLED) {
+			_forEachCompanyIdConcurrently(unsafeConsumer);
 
 			return;
 		}
@@ -259,6 +270,56 @@ public class DBPartitionUtil {
 		}
 
 		return true;
+	}
+
+	private static void _forEachCompanyIdConcurrently(
+			UnsafeConsumer<Long, Exception> unsafeConsumer)
+		throws Exception {
+
+		if (_executorService == null) {
+			_executorService = Executors.newWorkStealingPool();
+		}
+
+		List<Future<Void>> futures = new ArrayList<>();
+
+		ThrowableCollector throwableCollector = new ThrowableCollector();
+
+		try {
+			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+				if (companyId == _defaultCompanyId) {
+					try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+							companyId)) {
+
+						unsafeConsumer.accept(companyId);
+					}
+				}
+				else {
+					Future<Void> future = _executorService.submit(
+						() -> {
+							try (SafeCloseable safeCloseable =
+									CompanyThreadLocal.lock(companyId)) {
+
+								unsafeConsumer.accept(companyId);
+							}
+
+							return null;
+						});
+
+					futures.add(future);
+				}
+			}
+		}
+		finally {
+			for (Future<Void> future : futures) {
+				future.get();
+			}
+		}
+
+		Throwable throwable = throwableCollector.getThrowable();
+
+		if (throwable != null) {
+			ReflectionUtil.throwException(throwable);
+		}
 	}
 
 	private static Connection _getConnectionWrapper(Connection connection) {
@@ -670,7 +731,7 @@ public class DBPartitionUtil {
 
 	private static final boolean _DATABASE_PARTITION_THREAD_POOL_ENABLED =
 		GetterUtil.getBoolean(
-			PropsUtil.get("database.partition.thread.pool.enabled"));
+			PropsUtil.get("database.partition.thread.pool.enabled"), true);
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DBPartitionUtil.class);
@@ -679,5 +740,6 @@ public class DBPartitionUtil {
 		Arrays.asList("Company", "VirtualHost"));
 	private static volatile long _defaultCompanyId;
 	private static String _defaultSchemaName;
+	private static ExecutorService _executorService;
 
 }

--- a/portal-impl/src/portal-liferay-online.properties
+++ b/portal-impl/src/portal-liferay-online.properties
@@ -1,5 +1,6 @@
 database.partition.enabled=true
 database.partition.migrate.enabled=false
+database.partition.thread.pool.enabled=true
 enterprise.product.commerce.enabled=true
 session.timeout.auto.extend=true
 session.timeout.auto.extend.offset=300


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-139342>

__Notes:__
Added multithreading when processing company IDs. For now, I decided to use a work-stealing pool and keep it open while the portal is running, but let me know if we need to change any of that. Also, added a new portal property (`database.partition.thread.pool.enabled`) in case we need the option to enable/disable multithreading.

Let me know if you have any thoughts/questions. Thank you!