### PR TITLE
LPS-160370 Disable cache for system company for now as system company…

### DIFF
--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/ShardedEhcachePortalCache.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/ShardedEhcachePortalCache.java
@@ -15,7 +15,9 @@
 package com.liferay.portal.cache.ehcache.internal;
 
 import com.liferay.portal.cache.ehcache.internal.event.PortalCacheCacheEventListener;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.ProxyFactory;
 
 import java.io.Serializable;
 
@@ -46,8 +48,14 @@ public class ShardedEhcachePortalCache<K extends Serializable, V>
 
 	@Override
 	public Ehcache getEhcache() {
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			return _DUMMY_EHCACHE;
+		}
+
 		return _ehcaches.computeIfAbsent(
-			CompanyThreadLocal.getCompanyId(),
+			companyId,
 			key -> {
 				String shardedPortalCacheName =
 					getPortalCacheName() + _SHARDED_SEPARATOR + key;
@@ -119,6 +127,9 @@ public class ShardedEhcachePortalCache<K extends Serializable, V>
 	protected void resetEhcache() {
 		_ehcaches.clear();
 	}
+
+	private static final Ehcache _DUMMY_EHCACHE = ProxyFactory.newDummyInstance(
+		Ehcache.class);
 
 	private static final String _SHARDED_SEPARATOR = "_SHARDED_SEPARATOR_";
 


### PR DESCRIPTION
… and default company are currently mixed used by developers and causes stale object issue. We should make company thread local consistent with the company it works with, once we fixed all the mixed usages, we can remove this fix