### PR TITLE
LPS-178325 DO NOT MERGE Set upgrade timeout to 1 hour

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16256,7 +16256,7 @@ database.type=sqlserver
 				/>
 			</then>
 			<else>
-				<property name="upgrade.client.timeout" value="900000" />
+				<property name="upgrade.client.timeout" value="3600000" />
 			</else>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -14,7 +14,6 @@ definition {
 	@priority = 5
 	test CanAutoUpgradeLargePartitionedDatabase7413U47 {
 		property custom.properties = "upgrade.database.auto.run=true";
-		property custom.startup.timeout = "300";
 		property data.archive.type = "data-archive-portal-partition-large";
 		property minimum.slave.ram = "24";
 		property portal.release = "false";
@@ -31,7 +30,6 @@ definition {
 
 	@priority = 5
 	test CanUpgradeLargePartitionedDatabase7413U47 {
-		property custom.startup.timeout = "490";
 		property data.archive.type = "data-archive-portal-partition-large";
 		property minimum.slave.ram = "24";
 		property portal.release = "false";

--- a/test.properties
+++ b/test.properties
@@ -10469,7 +10469,7 @@
     test.smtp.server.url=http://mirrors.lax.liferay.com/repository.liferay.com/nexus/content/repositories/third-party/com/liferay/com.mockmock/1.4.0/com.mockmock-1.4.0.jar
     test.skip.tear.down=false
     #test.url=http://localhost:8080
-    timeout.app.server.wait=1800
+    timeout.app.server.wait=3600
     timeout.explicit.wait=120
     #unzip.executable=
 


### PR DESCRIPTION
Here's a temporary solution to test the performance tests without the custom timeout. 

- Upgrade tool will timeout after 1 hour.
- Auto-upgrade (including portal startup) will timeout after 1 hour. 

Let's try to see 1 hour is enough for now. CI has a timeout of 2 hours for the build which can't be modified easily without affecting other builds. 

Here's the ticket to investigate whether we want to make this a more permanent solution in the future. https://issues.liferay.com/browse/LPS-178694