### PR TITLE
LPS-185647 This doesn't work yet :(, but sending it in case you wanted to see my progress

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SessionImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SessionImpl.java
@@ -19,6 +19,7 @@ import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.sql.dsl.spi.ast.DefaultASTNodeListener;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.orm.LockMode;
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.Query;
@@ -229,6 +230,8 @@ public class SessionImpl implements Session {
 	@Override
 	public void delete(Object object) throws ORMException {
 		try {
+			DBPartitionUtil.checkCompanyThreadLocal(object);
+
 			_session.delete(object);
 		}
 		catch (Exception exception) {
@@ -340,6 +343,8 @@ public class SessionImpl implements Session {
 	@Override
 	public Object merge(Object object) throws ORMException {
 		try {
+			DBPartitionUtil.checkCompanyThreadLocal(object);
+
 			return _session.merge(object);
 		}
 		catch (Exception exception) {
@@ -350,6 +355,8 @@ public class SessionImpl implements Session {
 	@Override
 	public Serializable save(Object object) throws ORMException {
 		try {
+			DBPartitionUtil.checkCompanyThreadLocal(object);
+
 			return _session.save(object);
 		}
 		catch (Exception exception) {
@@ -360,6 +367,8 @@ public class SessionImpl implements Session {
 	@Override
 	public void saveOrUpdate(Object object) throws ORMException {
 		try {
+			DBPartitionUtil.checkCompanyThreadLocal(object);
+
 			_session.saveOrUpdate(object);
 		}
 		catch (Exception exception) {

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerFlushEntityEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerFlushEntityEventListener.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import java.util.Objects;
+
+import org.hibernate.HibernateException;
+import org.hibernate.event.spi.FlushEntityEvent;
+import org.hibernate.event.spi.FlushEntityEventListener;
+
+/**
+ * @author Alberto Chaparro
+ */
+public class CompanySynchronizerFlushEntityEventListener
+	implements FlushEntityEventListener {
+
+	public static final CompanySynchronizerFlushEntityEventListener INSTANCE =
+		new CompanySynchronizerFlushEntityEventListener();
+
+	@Override
+	public void onFlushEntity(FlushEntityEvent flushEntityEvent)
+		throws HibernateException {
+
+		Object entity = flushEntityEvent.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			long companyId = ((ShardedModel)entity).getCompanyId();
+
+			if (!Objects.equals(CompanyThreadLocal.getCompanyId(), companyId)) {
+				CompanyThreadLocal.setCompanyId(companyId);
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerFlushEntityEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerFlushEntityEventListener.java
@@ -14,20 +14,19 @@
 
 package com.liferay.portal.dao.orm.hibernate.event;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
-import java.util.Objects;
-
 import org.hibernate.HibernateException;
+import org.hibernate.event.internal.DefaultFlushEntityEventListener;
 import org.hibernate.event.spi.FlushEntityEvent;
-import org.hibernate.event.spi.FlushEntityEventListener;
 
 /**
  * @author Alberto Chaparro
  */
 public class CompanySynchronizerFlushEntityEventListener
-	implements FlushEntityEventListener {
+	extends DefaultFlushEntityEventListener {
 
 	public static final CompanySynchronizerFlushEntityEventListener INSTANCE =
 		new CompanySynchronizerFlushEntityEventListener();
@@ -39,11 +38,16 @@ public class CompanySynchronizerFlushEntityEventListener
 		Object entity = flushEntityEvent.getEntity();
 
 		if (entity instanceof ShardedModel) {
-			long companyId = ((ShardedModel)entity).getCompanyId();
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.
+						setInitializingCompanyIdWithSafeCloseable(
+							((ShardedModel)entity).getCompanyId())) {
 
-			if (!Objects.equals(CompanyThreadLocal.getCompanyId(), companyId)) {
-				CompanyThreadLocal.setCompanyId(companyId);
+				super.onFlushEntity(flushEntityEvent);
 			}
+		}
+		else {
+			super.onFlushEntity(flushEntityEvent);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -497,7 +497,7 @@ public class DBPartitionUtil {
 			}
 
 			private void _setCatalog() throws SQLException {
-				long companyId = CompanyThreadLocal.popCompanyId();
+				long companyId = CompanyThreadLocal.getCompanyId();
 
 				String schemaName = _getSchemaName(companyId);
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -52,6 +53,7 @@ import java.sql.Statement;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -120,6 +122,21 @@ public class DBPartitionUtil {
 		_companyIds.add(companyId);
 
 		return true;
+	}
+
+	public static void checkCompanyThreadLocal(Object object) {
+		if (!_DATABASE_PARTITION_ENABLED) {
+			return;
+		}
+
+		if ((object instanceof ShardedModel) &&
+			!Objects.equals(
+				CompanyThreadLocal.getCompanyId(),
+				((ShardedModel)object).getCompanyId())) {
+
+			throw new UnsupportedOperationException(
+				"Invalid partition for object");
+		}
 	}
 
 	public static void forEachCompanyId(

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -53,7 +53,6 @@ import java.sql.Statement;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -129,13 +128,18 @@ public class DBPartitionUtil {
 			return;
 		}
 
-		if ((object instanceof ShardedModel) &&
-			!Objects.equals(
-				CompanyThreadLocal.getCompanyId(),
-				((ShardedModel)object).getCompanyId())) {
+		if (object instanceof ShardedModel) {
+			long companyId = ((ShardedModel)object).getCompanyId();
 
-			throw new UnsupportedOperationException(
-				"Invalid partition for object");
+			if ((companyId != CompanyThreadLocal.getCompanyId()) &&
+				(companyId != CompanyConstants.SYSTEM) &&
+				((companyId != _defaultCompanyId) ||
+				 (CompanyThreadLocal.getCompanyId() !=
+					 CompanyConstants.SYSTEM))) {
+
+				throw new UnsupportedOperationException(
+					"Invalid partition for object");
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -22,6 +22,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.dao.jdbc.util.ConnectionWrapper;
 import com.liferay.portal.dao.jdbc.util.DataSourceWrapper;
 import com.liferay.portal.dao.jdbc.util.StatementWrapper;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerFlushEntityEventListener;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -57,6 +58,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.sql.DataSource;
+
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
 
 /**
  * @author Alberto Chaparro
@@ -165,6 +169,18 @@ public class DBPartitionUtil {
 
 	public static boolean isPartitionEnabled() {
 		return _DATABASE_PARTITION_ENABLED;
+	}
+
+	public static void registerEventListeners(
+		EventListenerRegistry eventListenerRegistry) {
+
+		if (!_DATABASE_PARTITION_ENABLED) {
+			return;
+		}
+
+		eventListenerRegistry.setListeners(
+			EventType.FLUSH_ENTITY,
+			CompanySynchronizerFlushEntityEventListener.INSTANCE);
 	}
 
 	public static boolean removeDBPartition(long companyId)
@@ -464,7 +480,7 @@ public class DBPartitionUtil {
 			}
 
 			private void _setCatalog() throws SQLException {
-				long companyId = CompanyThreadLocal.getCompanyId();
+				long companyId = CompanyThreadLocal.popCompanyId();
 
 				String schemaName = _getSchemaName(companyId);
 

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/GlobalEventListenerIntegrator.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/GlobalEventListenerIntegrator.java
@@ -16,6 +16,7 @@ package com.liferay.portal.spring.hibernate;
 
 import com.liferay.portal.dao.orm.hibernate.event.ResetOriginalValuesLoadEventListener;
 import com.liferay.portal.dao.orm.hibernate.event.ResetOriginalValuesPostLoadEventListener;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -46,6 +47,8 @@ public class GlobalEventListenerIntegrator implements Integrator {
 		EventListenerRegistry eventListenerRegistry =
 			sessionFactoryServiceRegistry.getService(
 				EventListenerRegistry.class);
+
+		DBPartitionUtil.registerEventListeners(eventListenerRegistry);
 
 		eventListenerRegistry.setListeners(
 			EventType.LOAD, ResetOriginalValuesLoadEventListener.INSTANCE);


### PR DESCRIPTION
Hi @achaparro,

I tested this against [LPS-184771](https://issues.liferay.com/browse/LPS-184771), and unfortunately, it does NOT resolve the issue. However, I am sending this anyway so that you can see the progress, and in case you had some time to work on it before my next working day. I haven't tested [LPS-185647](https://issues.liferay.com/browse/LPS-185647) yet because it's tedious for me to do so, due to an unrelated issue with my master branch.

I removed your commit to add the pop/push methods for companyId since I found it not to be necessary.

However, I think what you said about us needing to do this for the FlushEvent instead of (or in addition to?) the FlushEntityEvent is correct. Not only that, but I believe we also need to do this for the AutoFlushEvent. These all seem to be separate types of Events. The reason [LPS-184771](https://issues.liferay.com/browse/LPS-184771) is still occurring seems to be because it is happening during an AutoFlushEvent, which we don't have a Listener for yet.

However, I'm a bit concerned because I'm not sure how straightforward it will be (if it's even possible at all) to get the Entity that is being flushed during a FlushEvent or an AutoFlushEvent...