### PR TITLE
LPS-185647 Doesn't work yet due to not handling the possibility of adding SYSTEM companyIds to partitions

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPostDeleteEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPostDeleteEventListener.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * @author Michael Bowerman
+ */
+public class CompanySynchronizerPostDeleteEventListener
+	implements PostDeleteEventListener {
+
+	public static final CompanySynchronizerPostDeleteEventListener INSTANCE =
+		new CompanySynchronizerPostDeleteEventListener();
+
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			CompanyThreadLocal.popCompanyId();
+		}
+	}
+
+	/** @deprecated */
+	@Deprecated
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister entityPersister) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPostInsertEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPostInsertEventListener.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * @author Michael Bowerman
+ */
+public class CompanySynchronizerPostInsertEventListener
+	implements PostInsertEventListener {
+
+	public static final CompanySynchronizerPostInsertEventListener INSTANCE =
+		new CompanySynchronizerPostInsertEventListener();
+
+	public void onPostInsert(PostInsertEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			CompanyThreadLocal.popCompanyId();
+		}
+	}
+
+	/** @deprecated */
+	@Deprecated
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister entityPersister) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPostUpdateEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPostUpdateEventListener.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * @author Michael Bowerman
+ */
+public class CompanySynchronizerPostUpdateEventListener
+	implements PostUpdateEventListener {
+
+	public static final CompanySynchronizerPostUpdateEventListener INSTANCE =
+		new CompanySynchronizerPostUpdateEventListener();
+
+	public void onPostUpdate(PostUpdateEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			CompanyThreadLocal.popCompanyId();
+		}
+	}
+
+	/** @deprecated */
+	@Deprecated
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister entityPersister) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPreDeleteEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPreDeleteEventListener.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.hibernate.event.spi.PreDeleteEvent;
+import org.hibernate.event.spi.PreDeleteEventListener;
+
+/**
+ * @author Michael Bowerman
+ */
+public class CompanySynchronizerPreDeleteEventListener
+	implements PreDeleteEventListener {
+
+	public static final CompanySynchronizerPreDeleteEventListener INSTANCE =
+		new CompanySynchronizerPreDeleteEventListener();
+
+	public boolean onPreDelete(PreDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			ShardedModel shardedModel = (ShardedModel)entity;
+
+			CompanyThreadLocal.pushCompanyId(shardedModel.getCompanyId());
+		}
+
+		return false;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPreInsertEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPreInsertEventListener.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.hibernate.event.spi.PreInsertEvent;
+import org.hibernate.event.spi.PreInsertEventListener;
+
+/**
+ * @author Michael Bowerman
+ */
+public class CompanySynchronizerPreInsertEventListener
+	implements PreInsertEventListener {
+
+	public static final CompanySynchronizerPreInsertEventListener INSTANCE =
+		new CompanySynchronizerPreInsertEventListener();
+
+	public boolean onPreInsert(PreInsertEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			ShardedModel shardedModel = (ShardedModel)entity;
+
+			CompanyThreadLocal.pushCompanyId(shardedModel.getCompanyId());
+		}
+
+		return false;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPreUpdateEventListener.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/event/CompanySynchronizerPreUpdateEventListener.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.orm.hibernate.event;
+
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+
+/**
+ * @author Michael Bowerman
+ */
+public class CompanySynchronizerPreUpdateEventListener
+	implements PreUpdateEventListener {
+
+	public static final CompanySynchronizerPreUpdateEventListener INSTANCE =
+		new CompanySynchronizerPreUpdateEventListener();
+
+	public boolean onPreUpdate(PreUpdateEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof ShardedModel) {
+			ShardedModel shardedModel = (ShardedModel)entity;
+
+			CompanyThreadLocal.pushCompanyId(shardedModel.getCompanyId());
+		}
+
+		return false;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -22,6 +22,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.dao.jdbc.util.ConnectionWrapper;
 import com.liferay.portal.dao.jdbc.util.DataSourceWrapper;
 import com.liferay.portal.dao.jdbc.util.StatementWrapper;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerPostDeleteEventListener;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerPostInsertEventListener;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerPostUpdateEventListener;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerPreDeleteEventListener;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerPreInsertEventListener;
+import com.liferay.portal.dao.orm.hibernate.event.CompanySynchronizerPreUpdateEventListener;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -41,6 +47,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.spring.hibernate.DialectDetector;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -165,6 +173,33 @@ public class DBPartitionUtil {
 
 	public static boolean isPartitionEnabled() {
 		return _DATABASE_PARTITION_ENABLED;
+	}
+
+	public static void registerEventListeners(
+		EventListenerRegistry eventListenerRegistry) {
+
+		if (!_DATABASE_PARTITION_ENABLED) {
+			return;
+		}
+
+		eventListenerRegistry.appendListeners(
+			EventType.POST_DELETE,
+			CompanySynchronizerPostDeleteEventListener.INSTANCE);
+		eventListenerRegistry.appendListeners(
+			EventType.POST_INSERT,
+			CompanySynchronizerPostInsertEventListener.INSTANCE);
+		eventListenerRegistry.appendListeners(
+			EventType.POST_UPDATE,
+			CompanySynchronizerPostUpdateEventListener.INSTANCE);
+		eventListenerRegistry.appendListeners(
+			EventType.PRE_DELETE,
+			CompanySynchronizerPreDeleteEventListener.INSTANCE);
+		eventListenerRegistry.appendListeners(
+			EventType.PRE_INSERT,
+			CompanySynchronizerPreInsertEventListener.INSTANCE);
+		eventListenerRegistry.appendListeners(
+			EventType.PRE_UPDATE,
+			CompanySynchronizerPreUpdateEventListener.INSTANCE);
 	}
 
 	public static boolean removeDBPartition(long companyId)

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/GlobalEventListenerIntegrator.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/GlobalEventListenerIntegrator.java
@@ -17,6 +17,7 @@ package com.liferay.portal.spring.hibernate;
 import com.liferay.portal.dao.orm.hibernate.event.ResetOriginalValuesLoadEventListener;
 import com.liferay.portal.dao.orm.hibernate.event.ResetOriginalValuesPostLoadEventListener;
 
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import org.hibernate.boot.Metadata;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.service.spi.EventListenerRegistry;
@@ -46,6 +47,8 @@ public class GlobalEventListenerIntegrator implements Integrator {
 		EventListenerRegistry eventListenerRegistry =
 			sessionFactoryServiceRegistry.getService(
 				EventListenerRegistry.class);
+
+		DBPartitionUtil.registerEventListeners(eventListenerRegistry);
 
 		eventListenerRegistry.setListeners(
 			EventType.LOAD, ResetOriginalValuesLoadEventListener.INSTANCE);

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/MVCCEventListenerIntegrator.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/MVCCEventListenerIntegrator.java
@@ -46,7 +46,7 @@ public class MVCCEventListenerIntegrator implements Integrator {
 			sessionFactoryServiceRegistry.getService(
 				EventListenerRegistry.class);
 
-		eventListenerRegistry.setListeners(
+		eventListenerRegistry.appendListeners(
 			EventType.POST_UPDATE,
 			MVCCSynchronizerPostUpdateEventListener.INSTANCE);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -85,6 +85,24 @@ public class CompanyThreadLocal {
 		};
 	}
 
+	public static long popCompanyId() {
+		Long companyId = _companyId.get();
+
+		if (!_needsPopCompanyId.get()) {
+			_companyId.remove();
+
+			_needsPopCompanyId.set(false);
+		}
+
+		return companyId;
+	}
+
+	public static void pushCompanyId(Long companyId) {
+		_companyId.set(companyId);
+
+		_needsPopCompanyId.set(true);
+	}
+
 	public static void setCompanyId(Long companyId) {
 		if (_setCompanyId(companyId)) {
 			CTCollectionThreadLocal.removeCTCollectionId();
@@ -252,6 +270,9 @@ public class CompanyThreadLocal {
 			CompanyThreadLocal.class + "._initializingPortalInstance",
 			() -> Boolean.FALSE);
 	private static final ThreadLocal<Boolean> _locked =
+		new CentralizedThreadLocal<>(
+			CompanyThreadLocal.class + "._locked", () -> Boolean.FALSE);
+	private static final ThreadLocal<Boolean> _needsPopCompanyId =
 		new CentralizedThreadLocal<>(
 			CompanyThreadLocal.class + "._locked", () -> Boolean.FALSE);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
Hey @achaparro,

I'm on PTO tomorrow but I wanted to send you my progress thus far on the fix we discussed.

It doesn't work yet as new companies will fail to be added with the following error:
```
2023-06-19 23:57:01.972 ERROR [http-nio-8080-exec-5][BatchingBatch:134] HHH000315: Exception executing batch [java.sql.BatchUpdateException: Duplicate entry '0-0' for key 'dlfileentrytype.PRIMARY'], SQL: insert into DLFileEntryType (mvccVersion, ctCollectionId, uuid_, groupId, companyId, userId, userName, createDate, modifiedDate, dataDefinitionId, fileEntryTypeKey, name, description, scope, lastPublishDate, fileEntryTypeId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
2023-06-19 23:57:01.980 ERROR [http-nio-8080-exec-5][SqlExceptionHelper:142] Duplicate entry '0-0' for key 'dlfileentrytype.PRIMARY'
```

This is most likely because of the "BASIC DOCUMENT" DLFileEntryType which we try to add to the company using companyId 0 (see [here|https://github.com/liferay/liferay-portal/blob/f4e46e67ed7a31ab080f882425263ca980d667f2/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L244-L247] and [here|https://github.com/liferay/liferay-portal/blob/f4e46e67ed7a31ab080f882425263ca980d667f2/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java#L323]).

Do you think that we should disallow this possibility, and instead force the DLFileEntryType to be created with the actual companyId of the company? However, if we do this, I suspect that additional logic may need to be updated elsewhere to handle this.

Otherwise, we could solve this problem by making it so that the "Pre*EventListeners" avoid setting the CompanyThreadLocal if the companyId is set to SYSTEM. But this introduces the possibility that we still commit the transaction to the wrong partition if the companyId is set to SYSTEM.

What do you think?