### PR TITLE
LPS-190861 Set CompanyThreadLocal correctly for sharding

### DIFF
--- a/modules/apps/on-demand-admin/on-demand-admin-impl/build.gradle
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/build.gradle
@@ -11,5 +11,6 @@ dependencies {
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/ticket/generator/OnDemandAdminTicketGeneratorImpl.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/ticket/generator/OnDemandAdminTicketGeneratorImpl.java
@@ -84,14 +84,19 @@ public class OnDemandAdminTicketGeneratorImpl
 		int expirationTime =
 			onDemandAdminConfiguration.authenticationTokenExpirationTime();
 
-		return _ticketLocalService.addDistinctTicket(
-			user.getCompanyId(), User.class.getName(), user.getUserId(),
-			OnDemandAdminConstants.TICKET_TYPE_ON_DEMAND_ADMIN_LOGIN,
-			justification,
-			new Date(
-				System.currentTimeMillis() +
-					TimeUnit.MINUTES.toMillis(expirationTime)),
-			null);
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(
+					company.getCompanyId())) {
+
+			return _ticketLocalService.addDistinctTicket(
+				user.getCompanyId(), User.class.getName(), user.getUserId(),
+				OnDemandAdminConstants.TICKET_TYPE_ON_DEMAND_ADMIN_LOGIN,
+				justification,
+				new Date(
+					System.currentTimeMillis() +
+						TimeUnit.MINUTES.toMillis(expirationTime)),
+				null);
+		}
 	}
 
 	private User _addOnDemandAdminUser(

--- a/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/ticket/generator/OnDemandAdminTicketGeneratorImpl.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/ticket/generator/OnDemandAdminTicketGeneratorImpl.java
@@ -119,7 +119,7 @@ public class OnDemandAdminTicketGeneratorImpl
 			String password = PwdGenerator.getPassword(20);
 
 			User user = _userLocalService.addUser(
-				userId, companyId, false, password, password, true, null,
+				0, companyId, false, password, password, true, null,
 				emailAddress, locale, firstName, middleName, lastName, 0, 0,
 				male, date.getMonth(), date.getDay(), date.getYear(), null,
 				UserConstants.TYPE_REGULAR, null, null,


### PR DESCRIPTION
Hi @achaparro ! Here are my proposed changes to fix the on-demand admin portlet in a Sharding environment.  It is a tactical fix for this portlet only, because I think your intention is to not use a defensive strategy like setting the CompanyThreadLocal whenever there is a SB service invocation. Because cross company interactions are rare.