### PR TITLE
LPS-194500 Make Configuration a partitioned control table

### DIFF
--- a/modules/apps/asset/asset-publisher-layout-prototype/src/main/java/com/liferay/asset/publisher/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/asset/asset-publisher-layout-prototype/src/main/java/com/liferay/asset/publisher/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.asset.publisher.layout.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER, "LayoutPrototype",

--- a/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.blogs.layout.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER, "LayoutPrototype",

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -25,7 +26,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -87,7 +87,7 @@ public class CompanyLocalServiceDBPartitionTest
 			standaloneDBPartition = true;
 
 			Company defaultCompany = _companyLocalService.getCompany(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			try {
 				_company = _companyLocalService.addDBPartitionCompany(
@@ -99,10 +99,10 @@ public class CompanyLocalServiceDBPartitionTest
 				Assert.fail("Should fail due to duplicate web ID");
 			}
 			catch (PortalException portalException) {
-				long[] companyIds = PortalInstances.getCompanyIdsBySQL();
-
 				Assert.assertFalse(
-					ArrayUtil.contains(companyIds, _company.getCompanyId()));
+					ArrayUtil.contains(
+						PortalInstancePool.getCompanyIds(),
+						_company.getCompanyId()));
 
 				_checkStandaloneDBPartitionTables(
 					_company.getCompanyId(), "Company", "VirtualHost");
@@ -133,10 +133,10 @@ public class CompanyLocalServiceDBPartitionTest
 
 			standaloneDBPartition = false;
 
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
-
 			Assert.assertTrue(
-				ArrayUtil.contains(companyIds, _company.getCompanyId()));
+				ArrayUtil.contains(
+					PortalInstancePool.getCompanyIds(),
+					_company.getCompanyId()));
 
 			Assert.assertEquals(name, _company.getName());
 			Assert.assertEquals(virtualHostName, _company.getVirtualHostname());

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.NoSuchPasswordPolicyException;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -183,7 +184,7 @@ public class CompanyLocalServiceTest {
 
 		_companyLocalService.deleteCompany(company.getCompanyId());
 
-		for (String webId : PortalInstances.getWebIds()) {
+		for (String webId : PortalInstancePool.getWebIds()) {
 			Assert.assertNotEquals(company.getWebId(), webId);
 		}
 	}
@@ -772,7 +773,7 @@ public class CompanyLocalServiceTest {
 
 	@Test(expected = RequiredCompanyException.class)
 	public void testDeleteDefaultCompany() throws Exception {
-		long companyId = PortalInstances.getDefaultCompanyId();
+		long companyId = PortalInstancePool.getDefaultCompanyId();
 
 		_companyLocalService.deleteCompany(companyId);
 	}
@@ -798,7 +799,7 @@ public class CompanyLocalServiceTest {
 	public void testextractDBPartitionCompanyDefaultCompany() {
 		try {
 			_companyLocalService.extractDBPartitionCompany(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			Assert.fail();
 		}

--- a/modules/apps/document-library/document-library-layout-set-prototype/src/main/java/com/liferay/document/library/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/document-library/document-library-layout-set-prototype/src/main/java/com/liferay/document/library/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.document.library.layout.set.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER,

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.fragment.service.FragmentCollectionServiceUtil;
 import com.liferay.fragment.web.internal.util.FragmentPortletUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
@@ -20,7 +21,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.util.PortalInstances;
 
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
@@ -97,7 +97,7 @@ public class FragmentCollectionsDisplayContext {
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
 		if ((themeDisplay.getCompanyId() ==
-				PortalInstances.getDefaultCompanyId()) &&
+				PortalInstancePool.getDefaultCompanyId()) &&
 			scopeGroup.isCompany()) {
 
 			groupIds = ArrayUtil.append(groupIds, CompanyConstants.SYSTEM);

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -51,7 +52,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -734,7 +734,7 @@ public class FragmentDisplayContext {
 
 		if ((fragmentCollection.getGroupId() == CompanyConstants.SYSTEM) &&
 			((_themeDisplay.getCompanyId() !=
-				PortalInstances.getDefaultCompanyId()) ||
+				PortalInstancePool.getDefaultCompanyId()) ||
 			 !scopeGroup.isCompany())) {
 
 			return true;

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -10,6 +10,7 @@ import com.liferay.layout.utility.page.kernel.request.contributor.StatusLayoutUt
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -32,7 +33,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
@@ -151,7 +151,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			companyId = virtualHost.getCompanyId();
 		}
 		else {
-			companyId = PortalInstances.getDefaultCompanyId();
+			companyId = PortalInstancePool.getDefaultCompanyId();
 		}
 
 		Group group = _groupLocalService.fetchFriendlyURLGroup(

--- a/modules/apps/message-boards/message-boards-layout-set-prototype/src/main/java/com/liferay/message/boards/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/message-boards/message-boards-layout-set-prototype/src/main/java/com/liferay/message/boards/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.message.boards.layout.set.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER,

--- a/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/helper/OnDemandAdminHelper.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/helper/OnDemandAdminHelper.java
@@ -8,6 +8,7 @@ package com.liferay.on.demand.admin.internal.helper;
 import com.liferay.on.demand.admin.constants.OnDemandAdminActionKeys;
 import com.liferay.on.demand.admin.constants.OnDemandAdminPortletKeys;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.User;
@@ -15,7 +16,6 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
-import com.liferay.portal.util.PortalInstances;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -30,14 +30,14 @@ public class OnDemandAdminHelper {
 			long companyId, long userId)
 		throws PortalException {
 
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new PrincipalException(
 				"Target company must not be the default company");
 		}
 
 		User user = _userLocalService.getUser(userId);
 
-		if (user.getCompanyId() != PortalInstances.getDefaultCompanyId()) {
+		if (user.getCompanyId() != PortalInstancePool.getDefaultCompanyId()) {
 			throw new PrincipalException(
 				"Request can only be made from the default company");
 		}

--- a/modules/apps/on-demand-admin/on-demand-admin-test/src/testIntegration/java/com/liferay/on/demand/admin/ticket/generator/test/OnDemandAdminTicketGeneratorDBPartitionTest.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-test/src/testIntegration/java/com/liferay/on/demand/admin/ticket/generator/test/OnDemandAdminTicketGeneratorDBPartitionTest.java
@@ -7,7 +7,6 @@ package com.liferay.on.demand.admin.ticket.generator.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.on.demand.admin.ticket.generator.OnDemandAdminTicketGenerator;
-import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Ticket;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.model.UserWrapper;
 import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.security.DefaultAdminUtil;
 import com.liferay.portal.test.rule.Inject;
 
@@ -37,25 +35,12 @@ public class OnDemandAdminTicketGeneratorDBPartitionTest
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
-		addDBPartitions();
-
-		DBPartitionUtil.forEachCompanyId(
-			company -> ResourceActionLocalServiceUtil.checkResourceActions());
-
-		insertPartitionRequiredData();
-
-		insertPartitionData();
+		setUpDBPartitions();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		deletePartitionRequiredData();
-
-		removeDBPartitions();
-
-		disableDBPartition();
+		tearDownDBPartitions();
 	}
 
 	@Test

--- a/modules/apps/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTestUtil.java
+++ b/modules/apps/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTestUtil.java
@@ -125,7 +125,7 @@ public class ConfigurationTestUtil {
 
 		Assert.assertNotNull(factoryPid);
 
-		CountDownLatch countDownLatch = new CountDownLatch(1);
+		CountDownLatch countDownLatch = new CountDownLatch(2);
 
 		ServiceRegistration<ManagedServiceFactory> serviceRegistration =
 			_bundleContext.registerService(

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.instances.service.base.PortalInstancesLocalServiceBaseImpl;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -84,12 +85,12 @@ public class PortalInstancesLocalServiceImpl
 
 	@Override
 	public long[] getCompanyIds() {
-		return PortalInstances.getCompanyIds();
+		return PortalInstancePool.getCompanyIds();
 	}
 
 	@Override
 	public long getDefaultCompanyId() {
-		return PortalInstances.getDefaultCompanyId();
+		return PortalInstancePool.getDefaultCompanyId();
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/BackupAndRestoreIndexesTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/BackupAndRestoreIndexesTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.IndexAdminHelper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -15,7 +16,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +40,7 @@ public class BackupAndRestoreIndexesTest {
 	public void testBackupAndRestore() throws Exception {
 		Map<Long, String> backupNames = new HashMap<>();
 
-		for (long companyId : PortalInstances.getCompanyIds()) {
+		for (long companyId : PortalInstancePool.getCompanyIds()) {
 			String backupName = StringUtil.lowerCase(
 				BackupAndRestoreIndexesTest.class.getName());
 

--- a/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
+++ b/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
@@ -1,5 +1,4 @@
 Bundle-Name: Liferay Portal DB Partition Test Utilities
 Bundle-SymbolicName: com.liferay.portal.db.partition.test.util
-Bundle-Version: 2.0.3
 Bundle-Version: 2.1.0
 Export-Package: com.liferay.portal.db.partition.test.util

--- a/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
+++ b/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
@@ -1,4 +1,5 @@
 Bundle-Name: Liferay Portal DB Partition Test Utilities
 Bundle-SymbolicName: com.liferay.portal.db.partition.test.util
 Bundle-Version: 2.0.3
+Bundle-Version: 2.1.0
 Export-Package: com.liferay.portal.db.partition.test.util

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -451,6 +451,24 @@ public abstract class BaseDBPartitionTestCase {
 		_executeOnDBPartitions(companyIds, DBPartitionUtil::removeDBPartition);
 	}
 
+	protected static void setUpDBPartitions() throws Exception {
+		enableDBPartition();
+
+		addDBPartitions();
+
+		insertPartitionRequiredData();
+
+		insertPartitionData();
+	}
+
+	protected static void tearDownDBPartitions() throws Exception {
+		deletePartitionRequiredData();
+
+		removeDBPartitions();
+
+		disableDBPartition();
+	}
+
 	protected void createAndPopulateControlTable(String tableName)
 		throws Exception {
 

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -612,10 +612,8 @@ public abstract class BaseDBPartitionTestCase {
 	private static final String _DATABASE_PARTITION_SCHEMA_NAME_PREFIX =
 		"lpartitiontest_";
 
-	private static DataSource _currentDataSource;
-
 	private static Set<String> _controlTableNames;
-
+	private static DataSource _currentDataSource;
 	private static boolean _dbPartitionEnabled;
 
 	@Inject

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -20,20 +20,29 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.model.impl.ClassNameImpl;
+import com.liferay.portal.model.impl.ResourceActionImpl;
+import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -44,6 +53,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import java.util.Map;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -95,6 +107,9 @@ public abstract class BaseDBPartitionTestCase {
 				CurrentConnectionUtil.class, "_currentConnection",
 				defaultCurrentConnection);
 		}
+
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> _resourceActionLocalService.checkResourceActions());
 	}
 
 	protected static void createControlTable(String tableName)
@@ -102,6 +117,13 @@ public abstract class BaseDBPartitionTestCase {
 
 		db.runSQL(
 			"create table " + tableName + " (testColumn bigint primary key)");
+
+		if (_controlTableNames == null) {
+			_controlTableNames = ReflectionTestUtil.getFieldValue(
+				DBInspector.class, "_controlTableNames");
+		}
+
+		_controlTableNames.add(StringUtil.toLowerCase(TEST_CONTROL_TABLE_NAME));
 	}
 
 	protected static void createIndex(String tableName) throws Exception {
@@ -135,6 +157,8 @@ public abstract class BaseDBPartitionTestCase {
 						"delete from VirtualHost where companyId = " +
 							companyId);
 				}
+
+				PortalInstancePool.remove(companyId);
 			}
 		}
 	}
@@ -161,6 +185,27 @@ public abstract class BaseDBPartitionTestCase {
 		ReflectionTestUtil.setFieldValue(
 			DBPartitionUtil.class, "_DATABASE_PARTITION_SCHEMA_NAME_PREFIX",
 			StringPool.BLANK);
+
+		_entityCache.removeCache(ClassNameImpl.class.getName());
+		_entityCache.removeCache(ResourceActionImpl.class.getName());
+
+		_finderCache.removeCache(ClassNameImpl.class.getName());
+		_finderCache.removeCache(ResourceActionImpl.class.getName());
+
+		if (_resourceActions != null) {
+			_resourceActions.clear();
+		}
+
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> _resourceActionLocalService.checkResourceActions());
+	}
+
+	protected static void dropControlTable(String tableName) throws Exception {
+		db.runSQL("drop table if exists " + tableName);
+
+		if (_controlTableNames != null) {
+			_controlTableNames.remove(StringUtil.toLowerCase(tableName));
+		}
 	}
 
 	protected static void dropIndex(String tableName) throws Exception {
@@ -226,6 +271,20 @@ public abstract class BaseDBPartitionTestCase {
 		connection = DataAccess.getConnection();
 
 		dbInspector = new DBInspector(connection);
+
+		_entityCache.removeCache(ClassNameImpl.class.getName());
+		_entityCache.removeCache(ResourceActionImpl.class.getName());
+
+		_finderCache.removeCache(ClassNameImpl.class.getName());
+		_finderCache.removeCache(ResourceActionImpl.class.getName());
+
+		_resourceActions = ReflectionTestUtil.getFieldValue(
+			ResourceActionLocalServiceImpl.class, "_resourceActions");
+
+		_resourceActions.clear();
+
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> _resourceActionLocalService.checkResourceActions());
 	}
 
 	protected static void extractDBPartitions() throws Exception {
@@ -377,6 +436,8 @@ public abstract class BaseDBPartitionTestCase {
 
 				preparedStatement2.executeUpdate();
 			}
+
+			PortalInstancePool.add(companyId, "Test" + companyId);
 		}
 	}
 
@@ -393,11 +454,9 @@ public abstract class BaseDBPartitionTestCase {
 	protected void createAndPopulateControlTable(String tableName)
 		throws Exception {
 
-		try (Statement statement = connection.createStatement()) {
-			statement.execute(
-				"create table " + tableName +
-					" (testColumn bigint primary key)");
+		createControlTable(tableName);
 
+		try (Statement statement = connection.createStatement()) {
 			statement.execute("insert into " + tableName + " values (1)");
 		}
 	}
@@ -536,12 +595,27 @@ public abstract class BaseDBPartitionTestCase {
 		"lpartitiontest_";
 
 	private static DataSource _currentDataSource;
+
+	private static Set<String> _controlTableNames;
+
 	private static boolean _dbPartitionEnabled;
+
+	@Inject
+	private static EntityCache _entityCache;
+
+	@Inject
+	private static FinderCache _finderCache;
+
 	private static LazyConnectionDataSourceProxy _lazyConnectionDataSourceProxy;
 	private static String _originalDatabasePartitionEnabled;
 
 	@Inject
 	private static Props _props;
+
+	@Inject
+	private static ResourceActionLocalService _resourceActionLocalService;
+
+	private static Map<String, ResourceAction> _resourceActions;
 
 	@Inject
 	private static ServiceComponentRuntime _serviceComponentRuntime;

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.model.impl.ClassNameImpl;
+import com.liferay.portal.model.impl.CompanyImpl;
 import com.liferay.portal.model.impl.ResourceActionImpl;
 import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
 import com.liferay.portal.test.rule.Inject;
@@ -437,7 +438,12 @@ public abstract class BaseDBPartitionTestCase {
 				preparedStatement2.executeUpdate();
 			}
 
-			PortalInstancePool.add(companyId, "Test" + companyId);
+			Company company = new CompanyImpl();
+
+			company.setCompanyId(companyId);
+			company.setWebId("Test" + companyId);
+
+			PortalInstancePool.add(company);
 		}
 	}
 

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -46,7 +46,6 @@ import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
@@ -225,7 +224,8 @@ public abstract class BaseDBPartitionTestCase {
 	}
 
 	protected static void enableDBPartition() throws Exception {
-		CompanyThreadLocal.setCompanyId(PortalInstances.getDefaultCompanyId());
+		CompanyThreadLocal.setCompanyId(
+			PortalInstancePool.getDefaultCompanyId());
 
 		_dbPartitionEnabled = DBPartition.isPartitionEnabled();
 

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/resources/com/liferay/portal/db/partition/test/util/packageinfo
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/resources/com/liferay/portal/db/partition/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal/portal-db-partition-test/build.gradle
+++ b/modules/apps/portal/portal-db-partition-test/build.gradle
@@ -4,6 +4,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-db-partition-test-util")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
+	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-persistence-api")
+	testIntegrationImplementation project(":apps:static:portal-file-install:portal-file-install-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
@@ -1,0 +1,341 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.file.install.deploy.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.db.partition.DBPartitionUtil;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.file.install.FileInstaller;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.util.PropsValues;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Objects;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		enableDBPartition();
+
+		addDBPartitions();
+
+		insertPartitionRequiredData();
+
+		_companyId = TestPropsValues.getCompanyId();
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			DBPartitionFileInstallDeployTest.class);
+
+		try (ServiceTrackerList<FileInstaller> serviceTrackerList =
+				ServiceTrackerListFactory.open(
+					bundle.getBundleContext(), FileInstaller.class)) {
+
+			for (FileInstaller fileInstaller : serviceTrackerList.toList()) {
+				Class<?> clazz = fileInstaller.getClass();
+
+				if (Objects.equals(
+						clazz.getName(),
+						"com.liferay.portal.file.install.internal." +
+							"configuration.ConfigurationFileInstaller")) {
+
+					_fileInstaller = fileInstaller;
+
+					break;
+				}
+			}
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		deletePartitionRequiredData();
+
+		removeDBPartitions();
+
+		disableDBPartition();
+	}
+
+	@Test
+	public void testCompanyScopedConfiguration() throws Exception {
+		_testCompanyScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			COMPANY_IDS[1]);
+	}
+
+	@Test
+	public void testCompanyScopedPortableKeyConfiguration() throws Exception {
+		_testCompanyScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.COMPANY.
+				getPortablePropertyKey(),
+			"Test" + COMPANY_IDS[1]);
+	}
+
+	@Test
+	public void testGroupScopedConfiguration() throws Exception {
+		_testGroupScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+			RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testGroupScopedPortableKeyConfiguration() throws Exception {
+		_testGroupScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPortablePropertyKey(),
+			RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testPortletInstanceScopedConfiguration() throws Exception {
+		_testPortletInstanceScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey(),
+			RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testPortletInstanceScopedPortableKeyConfiguration()
+		throws Exception {
+
+		_testPortletInstanceScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPortablePropertyKey(),
+			RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testSystemScopedConfiguration() throws Exception {
+		_testScopedConfiguration(
+			null, null,
+			() -> _checkConfigurationExists(_companyId, _TEST_VALUE_1),
+			() -> _checkConfigurationExists(_companyId, _TEST_VALUE_2),
+			unsupportedOperationException -> Assert.fail(), true);
+	}
+
+	private void _checkConfiguration(
+			UnsafeBiConsumer<Long, ResultSet, Exception> unsafeBiConsumer)
+		throws Exception {
+
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select dictionary from Configuration_ where " +
+								"configurationId = ?")) {
+
+					preparedStatement.setString(1, _CONFIGURATION_FACTORY_PID);
+
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
+
+						unsafeBiConsumer.accept(companyId, resultSet);
+					}
+				}
+			});
+	}
+
+	private void _checkConfigurationExists(long companyId, String expectedValue)
+		throws Exception {
+
+		_checkConfiguration(
+			(currentCompanyId, resultSet) -> {
+				if (currentCompanyId == companyId) {
+					Assert.assertTrue(resultSet.next());
+
+					String value = resultSet.getString(1);
+
+					Assert.assertTrue(
+						value.contains(
+							StringBundler.concat(
+								_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
+								expectedValue, StringPool.QUOTE)));
+				}
+				else {
+					Assert.assertFalse(resultSet.next());
+				}
+			});
+	}
+
+	private void _checkConfigurationNotExists() throws Exception {
+		_checkConfiguration(
+			(companyId, resultSet) -> Assert.assertFalse(resultSet.next()));
+	}
+
+	private String _convertDictionaryValue(Object value) {
+		if (value instanceof Long) {
+			return StringBundler.concat("L\"", value, StringPool.QUOTE);
+		}
+
+		return StringBundler.concat(StringPool.QUOTE, value, StringPool.QUOTE);
+	}
+
+	private void _testCompanyScopedConfiguration(
+			String dictionaryKey, Object dictionaryValue)
+		throws Exception {
+
+		_testScopedConfiguration(
+			dictionaryKey, dictionaryValue,
+			() -> _checkConfigurationExists(COMPANY_IDS[1], _TEST_VALUE_1),
+			() -> _checkConfigurationExists(COMPANY_IDS[1], _TEST_VALUE_2),
+			unsupportedOperationException -> Assert.fail(), true);
+	}
+
+	private void _testGroupScopedConfiguration(
+			String dictionaryKey, Object dictionaryValue)
+		throws Exception {
+
+		_testScopedConfiguration(
+			dictionaryKey, dictionaryValue,
+			() -> _checkConfigurationNotExists(),
+			() -> _checkConfigurationNotExists(),
+			unsupportedOperationException -> Assert.assertEquals(
+				"Group scoped configuration files are not supported with " +
+					"Database Partition",
+				unsupportedOperationException.getMessage()),
+			false);
+	}
+
+	private void _testPortletInstanceScopedConfiguration(
+			String dictionaryKey, Object dictionaryValue)
+		throws Exception {
+
+		_testScopedConfiguration(
+			dictionaryKey, dictionaryValue,
+			() -> _checkConfigurationNotExists(),
+			() -> _checkConfigurationNotExists(),
+			unsupportedOperationException -> Assert.assertEquals(
+				"Portlet-instance scoped configuration files are not " +
+					"supported with Database Partition",
+				unsupportedOperationException.getMessage()),
+			false);
+	}
+
+	private void _testScopedConfiguration(
+			String dictionaryKey, Object dictionaryValue,
+			UnsafeRunnable<Exception> addValidatorRunnable,
+			UnsafeRunnable<Exception> updateValidatorRunnable,
+			UnsafeConsumer<UnsupportedOperationException, Exception>
+				exceptionValidatorConsumer,
+			boolean supportedConfiguration)
+		throws Exception {
+
+		Assert.assertNotNull(_fileInstaller);
+
+		Path path = Paths.get(
+			PropsValues.LIFERAY_HOME,
+			_CONFIGURATION_FACTORY_PID.concat(".config"));
+
+		try {
+			try {
+				String content = StringBundler.concat(
+					_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
+					_TEST_VALUE_1, StringPool.QUOTE);
+
+				if (dictionaryKey != null) {
+					content = StringBundler.concat(
+						content, StringPool.RETURN_NEW_LINE, dictionaryKey,
+						StringPool.EQUAL,
+						_convertDictionaryValue(dictionaryValue));
+				}
+
+				Files.write(path, content.getBytes());
+
+				_fileInstaller.transformURL(path.toFile());
+
+				if (!supportedConfiguration) {
+					Assert.fail();
+				}
+			}
+			catch (UnsupportedOperationException
+						unsupportedOperationException) {
+
+				exceptionValidatorConsumer.accept(
+					unsupportedOperationException);
+			}
+
+			addValidatorRunnable.run();
+
+			try {
+				String content = StringBundler.concat(
+					_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
+					_TEST_VALUE_2, StringPool.QUOTE);
+
+				if (dictionaryKey != null) {
+					content = StringBundler.concat(
+						content, StringPool.RETURN_NEW_LINE, dictionaryKey,
+						StringPool.EQUAL,
+						_convertDictionaryValue(dictionaryValue));
+				}
+
+				Files.write(path, content.getBytes());
+
+				_fileInstaller.transformURL(path.toFile());
+
+				if (!supportedConfiguration) {
+					Assert.fail();
+				}
+			}
+			catch (UnsupportedOperationException
+						unsupportedOperationException) {
+
+				exceptionValidatorConsumer.accept(
+					unsupportedOperationException);
+			}
+
+			updateValidatorRunnable.run();
+
+			Files.deleteIfExists(path);
+
+			_fileInstaller.uninstall(path.toFile());
+
+			_checkConfigurationNotExists();
+		}
+		finally {
+			Files.deleteIfExists(path);
+		}
+	}
+
+	private static final String _CONFIGURATION_FACTORY_PID =
+		DBPartitionFileInstallDeployTest.class.getName() + "Configuration~foo";
+
+	private static final String _TEST_KEY = "testKey";
+
+	private static final String _TEST_VALUE_1 = "testValue1";
+
+	private static final String _TEST_VALUE_2 = "testValue2";
+
+	private static long _companyId;
+	private static FileInstaller _fileInstaller;
+
+}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
@@ -19,16 +19,20 @@ import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.file.install.FileInstaller;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.Objects;
+
+import javax.sql.DataSource;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -76,6 +80,8 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 				}
 			}
 		}
+
+		_dataSource = InfrastructureUtil.getDataSource();
 	}
 
 	@AfterClass
@@ -149,7 +155,8 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> {
-				try (PreparedStatement preparedStatement =
+				try (Connection connection = _dataSource.getConnection();
+					PreparedStatement preparedStatement =
 						connection.prepareStatement(
 							"select dictionary from Configuration_ where " +
 								"configurationId = ?")) {
@@ -326,7 +333,8 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 
 			DBPartitionUtil.forEachCompanyId(
 				companyId -> {
-					try (PreparedStatement preparedStatement =
+					try (Connection connection = _dataSource.getConnection();
+						PreparedStatement preparedStatement =
 							connection.prepareStatement(
 								"delete from Configuration_ where " +
 									"configurationId = ?")) {
@@ -351,6 +359,7 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 	private static final String _TEST_VALUE_2 = "testValue2";
 
 	private static long _companyId;
+	private static DataSource _dataSource;
 	private static FileInstaller _fileInstaller;
 
 }

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
@@ -323,6 +323,21 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 		}
 		finally {
 			Files.deleteIfExists(path);
+
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> {
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(
+								"delete from Configuration_ where " +
+									"configurationId = ?")) {
+
+						preparedStatement.setString(
+							1, _CONFIGURATION_FACTORY_PID);
+						preparedStatement.executeUpdate();
+					}
+				});
+
+			_fileInstaller.uninstall(path.toFile());
 		}
 	}
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
@@ -51,11 +51,7 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
-		addDBPartitions();
-
-		insertPartitionRequiredData();
+		setUpDBPartitions();
 
 		_companyId = TestPropsValues.getCompanyId();
 
@@ -86,11 +82,7 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		deletePartitionRequiredData();
-
-		removeDBPartitions();
-
-		disableDBPartition();
+		tearDownDBPartitions();
 	}
 
 	@Test

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/BaseVirtualInstanceOperationTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/BaseVirtualInstanceOperationTestCase.java
@@ -43,10 +43,18 @@ public abstract class BaseVirtualInstanceOperationTestCase
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		enableDBPartition();
+
+		addDBPartitions();
+
+		insertPartitionRequiredData();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
+		deletePartitionRequiredData();
+
+		removeDBPartitions();
+
 		disableDBPartition();
 	}
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/BaseVirtualInstanceOperationTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/BaseVirtualInstanceOperationTestCase.java
@@ -42,20 +42,12 @@ public abstract class BaseVirtualInstanceOperationTestCase
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
-		addDBPartitions();
-
-		insertPartitionRequiredData();
+		setUpDBPartitions();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		deletePartitionRequiredData();
-
-		removeDBPartitions();
-
-		disableDBPartition();
+		tearDownDBPartitions();
 	}
 
 	@After

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionExtractVirtualInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionExtractVirtualInstanceOperationTest.java
@@ -24,7 +24,7 @@ public class DBPartitionExtractVirtualInstanceOperationTest
 
 	@Test
 	public void testDeployConfiguration() throws Exception {
-		deployConfiguration(_PID, "companyId=L\"0\"\n");
+		deployConfiguration(_PID, "partitionCompanyId=L\"0\"\n");
 
 		verifyConfigurationIsDeletedAfterDeploy(_PID);
 	}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertVirtualInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertVirtualInstanceOperationTest.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.db.partition.internal.operation.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +28,7 @@ public class DBPartitionInsertVirtualInstanceOperationTest
 		deployConfiguration(
 			_PID,
 			"newWebId=T\"testNewWebId\"\ncompanyId=L\"" +
-				PortalInstances.getDefaultCompanyId() + "\"\n");
+				PortalInstancePool.getDefaultCompanyId() + "\"\n");
 
 		verifyConfigurationIsDeletedAfterDeploy(_PID);
 	}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertVirtualInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertVirtualInstanceOperationTest.java
@@ -27,7 +27,7 @@ public class DBPartitionInsertVirtualInstanceOperationTest
 	public void testDeployConfiguration() throws Exception {
 		deployConfiguration(
 			_PID,
-			"newWebId=T\"testNewWebId\"\ncompanyId=L\"" +
+			"newWebId=T\"testNewWebId\"\npartitionCompanyId=L\"" +
 				PortalInstancePool.getDefaultCompanyId() + "\"\n");
 
 		verifyConfigurationIsDeletedAfterDeploy(_PID);

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -9,10 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
-import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.dao.orm.EntityCache;
-import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -24,13 +21,9 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.model.DefaultModelHintsImpl;
-import com.liferay.portal.model.impl.ClassNameImpl;
-import com.liferay.portal.model.impl.ResourceActionImpl;
 import com.liferay.portal.service.impl.ClassNameLocalServiceImpl;
 import com.liferay.portal.service.impl.CompanyLocalServiceImpl;
-import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PortalInstances;
@@ -42,7 +35,6 @@ import java.sql.ResultSet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -64,28 +56,9 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	public static void setUpClass() throws Exception {
 		enableDBPartition();
 
-		entityCache.removeCache(ClassNameImpl.class.getName());
-		entityCache.removeCache(ResourceActionImpl.class.getName());
-
-		finderCache.removeCache(ClassNameImpl.class.getName());
-		finderCache.removeCache(ResourceActionImpl.class.getName());
-
 		createControlTable(TEST_CONTROL_TABLE_NAME);
 
-		_controlTableNames = ReflectionTestUtil.getFieldValue(
-			DBInspector.class, "_controlTableNames");
-
-		_controlTableNames.add(StringUtil.toLowerCase(TEST_CONTROL_TABLE_NAME));
-
 		addDBPartitions();
-
-		_resourceActions = ReflectionTestUtil.getFieldValue(
-			ResourceActionLocalServiceImpl.class, "_resourceActions");
-
-		_resourceActions.clear();
-
-		DBPartitionUtil.forEachCompanyId(
-			companyId -> _resourceActionLocalService.checkResourceActions());
 
 		insertPartitionRequiredData();
 	}
@@ -96,25 +69,9 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 		removeDBPartitions();
 
-		dropTable(TEST_CONTROL_TABLE_NAME);
-
-		_controlTableNames.remove(
-			StringUtil.toLowerCase(TEST_CONTROL_TABLE_NAME));
+		dropControlTable(TEST_CONTROL_TABLE_NAME);
 
 		disableDBPartition();
-
-		entityCache.removeCache(ClassNameImpl.class.getName());
-		entityCache.removeCache(ResourceActionImpl.class.getName());
-
-		finderCache.removeCache(ClassNameImpl.class.getName());
-		finderCache.removeCache(ResourceActionImpl.class.getName());
-
-		if (_resourceActions != null) {
-			_resourceActions.clear();
-		}
-
-		DBPartitionUtil.forEachCompanyId(
-			companyId -> _resourceActionLocalService.checkResourceActions());
 	}
 
 	@After
@@ -494,29 +451,19 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	}
 
-	@Inject
-	protected static EntityCache entityCache;
-
-	@Inject
-	protected static FinderCache finderCache;
-
 	private static final String _CLASS_NAME_VALUE = "class.name.test";
 
 	private static final String _DB_PARTITION_SCHEMA_NAME_PREFIX =
 		"lpartitiontest_";
-
-	private static Set<String> _controlTableNames;
-
-	@Inject
-	private static ResourceActionLocalService _resourceActionLocalService;
-
-	private static Map<String, ResourceAction> _resourceActions;
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
 
 	private class ClassNameModelHints extends DefaultModelHintsImpl {
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.model.DefaultModelHintsImpl;
 import com.liferay.portal.model.impl.ClassNameImpl;
 import com.liferay.portal.model.impl.ResourceActionImpl;
@@ -70,6 +72,11 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 		createControlTable(TEST_CONTROL_TABLE_NAME);
 
+		_controlTableNames = ReflectionTestUtil.getFieldValue(
+			DBInspector.class, "_controlTableNames");
+
+		_controlTableNames.add(StringUtil.toLowerCase(TEST_CONTROL_TABLE_NAME));
+
 		addDBPartitions();
 
 		_resourceActions = ReflectionTestUtil.getFieldValue(
@@ -90,6 +97,9 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		removeDBPartitions();
 
 		dropTable(TEST_CONTROL_TABLE_NAME);
+
+		_controlTableNames.remove(
+			StringUtil.toLowerCase(TEST_CONTROL_TABLE_NAME));
 
 		disableDBPartition();
 
@@ -195,6 +205,31 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 				Assert.assertEquals(
 					finalClassNameId, className.getClassNameId());
 				Assert.assertEquals(finalClassNameValue, className.getValue());
+			});
+	}
+
+	@Test
+	public void testCopyConfiguration() throws Exception {
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> {
+				int rowCount = -1;
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select count(1) from Configuration_");
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						rowCount = resultSet.getInt(1);
+					}
+				}
+
+				if (PortalInstances.getDefaultCompanyId() == companyId) {
+					Assert.assertTrue(rowCount > 0);
+				}
+				else {
+					Assert.assertEquals(0, rowCount);
+				}
 			});
 	}
 
@@ -469,6 +504,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	private static final String _DB_PARTITION_SCHEMA_NAME_PREFIX =
 		"lpartitiontest_";
+
+	private static Set<String> _controlTableNames;
 
 	@Inject
 	private static ResourceActionLocalService _resourceActionLocalService;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -26,7 +27,6 @@ import com.liferay.portal.service.impl.ClassNameLocalServiceImpl;
 import com.liferay.portal.service.impl.CompanyLocalServiceImpl;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -173,7 +173,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 					}
 				}
 
-				if (PortalInstances.getDefaultCompanyId() == companyId) {
+				if (PortalInstancePool.getDefaultCompanyId() == companyId) {
 					Assert.assertTrue(rowCount > 0);
 				}
 				else {
@@ -417,7 +417,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 		dbPartitionUpgradeProcess.upgrade();
 
-		long[] expectedCompanyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] expectedCompanyIds = PortalInstancePool.getCompanyIds();
 
 		Arrays.sort(expectedCompanyIds);
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -54,24 +54,16 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
 		createControlTable(TEST_CONTROL_TABLE_NAME);
 
-		addDBPartitions();
-
-		insertPartitionRequiredData();
+		setUpDBPartitions();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		deletePartitionRequiredData();
-
-		removeDBPartitions();
-
 		dropControlTable(TEST_CONTROL_TABLE_NAME);
 
-		disableDBPartition();
+		tearDownDBPartitions();
 	}
 
 	@After

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -272,7 +272,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 					}
 				}
 				finally {
-					dropTable(TEST_CONTROL_TABLE_NAME);
+					dropControlTable(TEST_CONTROL_TABLE_NAME);
 				}
 			}
 		}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -13,12 +13,16 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -58,6 +62,8 @@ public class UpgradePartitionedConfigurationTableTest
 
 		insertPartitionRequiredData();
 
+		insertPartitionData();
+
 		_companyId = TestPropsValues.getCompanyId();
 
 		_dataSource = InfrastructureUtil.getDataSource();
@@ -87,12 +93,16 @@ public class UpgradePartitionedConfigurationTableTest
 				}
 			});
 
+		_omniAdminUser = UserTestUtil.addOmniAdminUser();
+
 		Group group = null;
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
 
-			group = GroupTestUtil.addGroup();
+			group = GroupTestUtil.addGroup(
+				COMPANY_IDS[0], _omniAdminUser.getUserId(),
+				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 		}
 
 		Map<Long, ConfigurationEntry> validConfigurationEntries =
@@ -270,6 +280,9 @@ public class UpgradePartitionedConfigurationTableTest
 	private static long _companyId;
 	private static DataSource _dataSource;
 	private static String _defaultSchemaName;
+
+	@DeleteAfterTestRun
+	private User _omniAdminUser;
 
 	private class ConfigurationEntry {
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -12,6 +12,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
@@ -231,7 +232,7 @@ public class UpgradePartitionedConfigurationTableTest
 							try (ResultSet resultSet =
 									preparedStatement.executeQuery()) {
 
-								if ((companyId == 0) ||
+								if ((companyId == CompanyConstants.SYSTEM) ||
 									Objects.equals(
 										currentCompanyId, companyId)) {
 
@@ -295,7 +296,7 @@ public class UpgradePartitionedConfigurationTableTest
 				UpgradePartitionedConfigurationTableTest.class.getName() + "~" +
 					RandomTestUtil.randomString();
 
-			String dictionary = "";
+			String dictionary = StringPool.BLANK;
 
 			if (scopeValue != null) {
 				dictionary = StringBundler.concat(

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -21,15 +21,19 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.Map;
 import java.util.Objects;
+
+import javax.sql.DataSource;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -55,6 +59,8 @@ public class UpgradePartitionedConfigurationTableTest
 		insertPartitionRequiredData();
 
 		_companyId = TestPropsValues.getCompanyId();
+
+		_dataSource = InfrastructureUtil.getDataSource();
 
 		_defaultSchemaName = connection.getCatalog();
 	}
@@ -202,7 +208,9 @@ public class UpgradePartitionedConfigurationTableTest
 
 				DBPartitionUtil.forEachCompanyId(
 					currentCompanyId -> {
-						try (PreparedStatement preparedStatement =
+						try (Connection connection =
+								_dataSource.getConnection();
+							PreparedStatement preparedStatement =
 								connection.prepareStatement(
 									"select dictionary from Configuration_ " +
 										"where configurationId = ?")) {
@@ -260,6 +268,7 @@ public class UpgradePartitionedConfigurationTableTest
 			"v2_0_0.ConfigurationUpgradeProcess";
 
 	private static long _companyId;
+	private static DataSource _dataSource;
 	private static String _defaultSchemaName;
 
 	private class ConfigurationEntry {

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -1,0 +1,310 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.db.partition.DBPartitionUtil;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class UpgradePartitionedConfigurationTableTest
+	extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		enableDBPartition();
+
+		addDBPartitions();
+
+		insertPartitionRequiredData();
+
+		_companyId = TestPropsValues.getCompanyId();
+
+		_defaultSchemaName = connection.getCatalog();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		deletePartitionRequiredData();
+
+		removeDBPartitions();
+
+		disableDBPartition();
+	}
+
+	@Test
+	public void testUpgradeProcess() throws Exception {
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> {
+				if (companyId != _companyId) {
+					db.runSQL("drop table if exists Configuration_");
+					db.runSQL(
+						StringBundler.concat(
+							"create or replace view Configuration_ as select ",
+							"* from ", _defaultSchemaName, ".Configuration_"));
+				}
+			});
+
+		Group group = null;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+
+			group = GroupTestUtil.addGroup();
+		}
+
+		Map<Long, ConfigurationEntry> validConfigurationEntries =
+			HashMapBuilder.<Long, ConfigurationEntry>put(
+				_companyId,
+				new ConfigurationEntry(
+					ExtendedObjectClassDefinition.Scope.SYSTEM, null)
+			).put(
+				0L,
+				new ConfigurationEntry(
+					ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+					RandomTestUtil.randomLong())
+			).put(
+				COMPANY_IDS[0],
+				new ConfigurationEntry(
+					ExtendedObjectClassDefinition.Scope.GROUP,
+					group.getGroupId())
+			).put(
+				COMPANY_IDS[1],
+				new ConfigurationEntry(
+					ExtendedObjectClassDefinition.Scope.COMPANY, COMPANY_IDS[1])
+			).build();
+
+		long randomCompanyId = RandomTestUtil.randomLong();
+		long randomGroupId = RandomTestUtil.randomLong();
+
+		Map<Long, ConfigurationEntry> invalidConfigurationEntries =
+			HashMapBuilder.<Long, ConfigurationEntry>put(
+				randomCompanyId,
+				new ConfigurationEntry(
+					ExtendedObjectClassDefinition.Scope.COMPANY,
+					randomCompanyId)
+			).put(
+				randomGroupId,
+				new ConfigurationEntry(
+					ExtendedObjectClassDefinition.Scope.GROUP, randomGroupId)
+			).build();
+
+		try {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"insert into Configuration_ (configurationId, " +
+							"dictionary) values (?, ?)")) {
+
+				for (ConfigurationEntry configurationEntry :
+						validConfigurationEntries.values()) {
+
+					preparedStatement.setString(1, configurationEntry.getPid());
+					preparedStatement.setString(
+						2, configurationEntry.getDictionary());
+
+					preparedStatement.executeUpdate();
+				}
+
+				for (ConfigurationEntry configurationEntry :
+						invalidConfigurationEntries.values()) {
+
+					preparedStatement.setString(1, configurationEntry.getPid());
+					preparedStatement.setString(
+						2, configurationEntry.getDictionary());
+
+					preparedStatement.executeUpdate();
+				}
+			}
+
+			Bundle bundle = BundleUtil.getBundle(
+				SystemBundleUtil.getBundleContext(),
+				"com.liferay.portal.configuration.persistence.impl");
+
+			Class<?> upgradeProcessClass = bundle.loadClass(
+				_UPGRADE_CLASS_NAME);
+
+			UpgradeProcess upgradeProcess =
+				(UpgradeProcess)upgradeProcessClass.newInstance();
+
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					_UPGRADE_CLASS_NAME, LoggerTestUtil.INFO)) {
+
+				upgradeProcess.upgrade();
+
+				String logMessage = StringUtil.merge(
+					logCapture.getLogEntries(), StringPool.NEW_LINE);
+
+				for (Map.Entry<Long, ConfigurationEntry>
+						configurationEntryEntry :
+							invalidConfigurationEntries.entrySet()) {
+
+					ConfigurationEntry configurationEntry =
+						configurationEntryEntry.getValue();
+
+					Assert.assertTrue(
+						logMessage.contains(
+							StringBundler.concat(
+								StringUtil.upperCaseFirstLetter(
+									configurationEntry.getScope(
+									).getValue()),
+								" scope configuration with ID ",
+								configurationEntry.getPid(),
+								" has been removed because the ",
+								configurationEntry.getScope(
+								).getValue(),
+								" ID ", configurationEntryEntry.getKey(),
+								" does not exists")));
+				}
+			}
+
+			for (Map.Entry<Long, ConfigurationEntry> configurationEntryEntry :
+					validConfigurationEntries.entrySet()) {
+
+				ConfigurationEntry configurationEntry =
+					configurationEntryEntry.getValue();
+				Long companyId = configurationEntryEntry.getKey();
+
+				DBPartitionUtil.forEachCompanyId(
+					currentCompanyId -> {
+						try (PreparedStatement preparedStatement =
+								connection.prepareStatement(
+									"select dictionary from Configuration_ " +
+										"where configurationId = ?")) {
+
+							preparedStatement.setString(
+								1, configurationEntry.getPid());
+
+							try (ResultSet resultSet =
+									preparedStatement.executeQuery()) {
+
+								if ((companyId == 0) ||
+									Objects.equals(
+										currentCompanyId, companyId)) {
+
+									Assert.assertTrue(resultSet.next());
+									Assert.assertEquals(
+										configurationEntry.getDictionary(),
+										resultSet.getString(1));
+								}
+								else {
+									Assert.assertFalse(resultSet.next());
+								}
+							}
+						}
+					});
+			}
+		}
+		finally {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"delete from Configuration_ where configurationId = " +
+							"?")) {
+
+				for (ConfigurationEntry configurationEntry :
+						validConfigurationEntries.values()) {
+
+					preparedStatement.setString(1, configurationEntry.getPid());
+
+					preparedStatement.executeUpdate();
+				}
+			}
+		}
+	}
+
+	private String _convertDictionaryValue(Object value) {
+		if (value instanceof Long) {
+			return StringBundler.concat("L\"", value, StringPool.QUOTE);
+		}
+
+		return StringBundler.concat(StringPool.QUOTE, value, StringPool.QUOTE);
+	}
+
+	private static final String _UPGRADE_CLASS_NAME =
+		"com.liferay.portal.configuration.persistence.internal.upgrade." +
+			"v2_0_0.ConfigurationUpgradeProcess";
+
+	private static long _companyId;
+	private static String _defaultSchemaName;
+
+	private class ConfigurationEntry {
+
+		public ConfigurationEntry(
+			ExtendedObjectClassDefinition.Scope scope, Object scopeValue) {
+
+			_scope = scope;
+
+			_pid =
+				UpgradePartitionedConfigurationTableTest.class.getName() + "~" +
+					RandomTestUtil.randomString();
+
+			String dictionary = "";
+
+			if (scopeValue != null) {
+				dictionary = StringBundler.concat(
+					scope.getPropertyKey(), StringPool.EQUAL,
+					_convertDictionaryValue(scopeValue));
+			}
+
+			dictionary = StringBundler.concat(
+				dictionary, StringPool.NEW_LINE, RandomTestUtil.randomString(),
+				StringPool.EQUAL, StringPool.QUOTE,
+				RandomTestUtil.randomString(), StringPool.QUOTE);
+
+			_dictionary = dictionary;
+		}
+
+		public String getDictionary() {
+			return _dictionary;
+		}
+
+		public String getPid() {
+			return _pid;
+		}
+
+		public ExtendedObjectClassDefinition.Scope getScope() {
+			return _scope;
+		}
+
+		private final String _dictionary;
+		private final String _pid;
+		private final ExtendedObjectClassDefinition.Scope _scope;
+
+	}
+
+}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -57,13 +57,7 @@ public class UpgradePartitionedConfigurationTableTest
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
-		addDBPartitions();
-
-		insertPartitionRequiredData();
-
-		insertPartitionData();
+		setUpDBPartitions();
 
 		_companyId = TestPropsValues.getCompanyId();
 
@@ -74,11 +68,7 @@ public class UpgradePartitionedConfigurationTableTest
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		deletePartitionRequiredData();
-
-		removeDBPartitions();
-
-		disableDBPartition();
+		tearDownDBPartitions();
 	}
 
 	@Test

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
@@ -10,9 +10,9 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.upgrade.util.UpgradePartitionedControlTable;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -100,7 +100,7 @@ public class UpgradePartitionedControlTableTest
 
 			DBPartitionUtil.forEachCompanyId(
 				companyId -> {
-					if (PortalInstances.getDefaultCompanyId() ==
+					if (PortalInstancePool.getDefaultCompanyId() ==
 							DBPartitionUtil.getCurrentCompanyId()) {
 
 						return;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
@@ -33,20 +33,12 @@ public class UpgradePartitionedControlTableTest
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		enableDBPartition();
-
-		addDBPartitions();
-
-		insertPartitionRequiredData();
+		setUpDBPartitions();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		deletePartitionRequiredData();
-
-		removeDBPartitions();
-
-		disableDBPartition();
+		tearDownDBPartitions();
 	}
 
 	@Test

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/configuration/DBPartitionExtractVirtualInstanceConfiguration.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/configuration/DBPartitionExtractVirtualInstanceConfiguration.java
@@ -19,6 +19,6 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface DBPartitionExtractVirtualInstanceConfiguration {
 
 	@Meta.AD(type = Meta.Type.Long)
-	public long companyId();
+	public long partitionCompanyId();
 
 }

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/configuration/DBPartitionInsertVirtualInstanceConfiguration.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/configuration/DBPartitionInsertVirtualInstanceConfiguration.java
@@ -19,7 +19,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface DBPartitionInsertVirtualInstanceConfiguration {
 
 	@Meta.AD(type = Meta.Type.Long)
-	public long companyId();
+	public long partitionCompanyId();
 
 	@Meta.AD(required = false)
 	public String newName();

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/operation/DBPartitionExtractVirtualInstanceOperation.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/operation/DBPartitionExtractVirtualInstanceOperation.java
@@ -39,7 +39,8 @@ public class DBPartitionExtractVirtualInstanceOperation
 							properties);
 
 				long companyId =
-					dBPartitionExtractVirtualInstanceConfiguration.companyId();
+					dBPartitionExtractVirtualInstanceConfiguration.
+						partitionCompanyId();
 
 				if (_companyLocalService.fetchCompany(companyId) == null) {
 					return null;

--- a/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/operation/DBPartitionInsertVirtualInstanceOperation.java
+++ b/modules/apps/portal/portal-db-partition/src/main/java/com/liferay/portal/db/partition/internal/operation/DBPartitionInsertVirtualInstanceOperation.java
@@ -40,7 +40,8 @@ public class DBPartitionInsertVirtualInstanceOperation
 							properties);
 
 				long companyId =
-					dBPartitionInsertVirtualInstanceConfiguration.companyId();
+					dBPartitionInsertVirtualInstanceConfiguration.
+						partitionCompanyId();
 
 				if (_companyLocalService.fetchCompany(companyId) != null) {
 					return null;

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
@@ -169,7 +170,8 @@ public class PortalInstancesTest {
 	public void testGetWebIdsAfterInitCompany() {
 		PortalInstances.initCompany(_company);
 
-		List<String> webIds = ListUtil.fromArray(PortalInstances.getWebIds());
+		List<String> webIds = ListUtil.fromArray(
+			PortalInstancePool.getWebIds());
 
 		Assert.assertTrue(webIds.contains(_company.getWebId()));
 
@@ -178,7 +180,7 @@ public class PortalInstancesTest {
 		PortalInstances.initCompany(
 			_companyLocalService.updateCompany(_company));
 
-		webIds = ListUtil.fromArray(PortalInstances.getWebIds());
+		webIds = ListUtil.fromArray(PortalInstancePool.getWebIds());
 
 		Assert.assertTrue(webIds.contains(_company.getWebId()));
 	}

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/build.gradle
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/build.gradle
@@ -6,11 +6,13 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:osgi:osgi-util")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:static:portal-file-install:portal-file-install-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -199,30 +199,27 @@ public class ConfigurationPersistenceManager
 		}
 	}
 
-	public void start() {
-		try {
+	public void start() throws Exception {
+		if (!StartupHelperUtil.isDBNew()) {
 			_populateDictionaries();
+
+			return;
 		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
 
-			_createConfigurationTable();
+		_createConfigurationTable();
 
-			for (Bundle bundle : _bundleContext.getBundles()) {
-				if (Objects.equals(
-						bundle.getSymbolicName(),
-						"org.apache.felix.configurator")) {
+		for (Bundle bundle : _bundleContext.getBundles()) {
+			if (Objects.equals(
+					bundle.getSymbolicName(),
+					"org.apache.felix.configurator")) {
 
-					File stateFile = bundle.getDataFile("state.ser");
+				File stateFile = bundle.getDataFile("state.ser");
 
-					if (stateFile.exists()) {
-						stateFile.delete();
-					}
-
-					break;
+				if (stateFile.exists()) {
+					stateFile.delete();
 				}
+
+				break;
 			}
 		}
 	}
@@ -437,11 +434,6 @@ public class ConfigurationPersistenceManager
 	}
 
 	private void _populateDictionaries() throws Exception {
-		if (StartupHelperUtil.isDBNew()) {
-			throw new Exception(
-				"Database is new. Configuration_ table does not exist.");
-		}
-
 		Map<String, Map<String, Object>> overridePropertiesMap = new HashMap<>(
 			ConfigurationOverridePropertiesUtil.getOverridePropertiesMap());
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -546,8 +546,8 @@ public class ConfigurationPersistenceManager
 
 		boolean needSave = false;
 
-		if (dictionary.get(_SERVIE_BUNDLE_LOCATION) == null) {
-			dictionary.put(_SERVIE_BUNDLE_LOCATION, "?");
+		if (dictionary.get(_SERVICE_BUNDLE_LOCATION) == null) {
+			dictionary.put(_SERVICE_BUNDLE_LOCATION, "?");
 
 			needSave = true;
 		}
@@ -621,7 +621,7 @@ public class ConfigurationPersistenceManager
 		}
 	}
 
-	private static final String _SERVIE_BUNDLE_LOCATION =
+	private static final String _SERVICE_BUNDLE_LOCATION =
 		"service.bundleLocation";
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -199,11 +199,18 @@ public class ConfigurationPersistenceManager
 		}
 	}
 
-	public void start() throws Exception {
-		if (!StartupHelperUtil.isDBNew()) {
-			_populateDictionaries();
+	public void start() {
+		try {
+			if (!StartupHelperUtil.isDBNew()) {
+				_populateDictionaries();
 
-			return;
+				return;
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
 		}
 
 		_createConfigurationTable();

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -16,6 +16,7 @@ import com.liferay.portal.configuration.persistence.ReloadablePersistenceManager
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.db.partition.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -436,6 +437,11 @@ public class ConfigurationPersistenceManager
 	}
 
 	private void _populateDictionaries() throws Exception {
+		if (StartupHelperUtil.isDBNew()) {
+			throw new Exception(
+				"Database is new. Configuration_ table does not exist.");
+		}
+
 		Map<String, Map<String, Object>> overridePropertiesMap = new HashMap<>(
 			ConfigurationOverridePropertiesUtil.getOverridePropertiesMap());
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -15,6 +15,7 @@ import com.liferay.portal.configuration.persistence.InMemoryOnlyConfigurationThr
 import com.liferay.portal.configuration.persistence.ReloadablePersistenceManager;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -201,7 +202,7 @@ public class ConfigurationPersistenceManager
 		try {
 			_populateDictionaries();
 		}
-		catch (IOException | SQLException exception) {
+		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(exception);
 			}
@@ -434,31 +435,37 @@ public class ConfigurationPersistenceManager
 		return dictionary;
 	}
 
-	private void _populateDictionaries() throws IOException, SQLException {
+	private void _populateDictionaries() throws Exception {
 		Map<String, Map<String, Object>> overridePropertiesMap = new HashMap<>(
 			ConfigurationOverridePropertiesUtil.getOverridePropertiesMap());
 
-		try (Connection connection = _dataSource.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				_db.buildSQL(
-					"select configurationId, dictionary from Configuration_"),
-				ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-			ResultSet resultSet = preparedStatement.executeQuery()) {
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> {
+				try (Connection connection = _dataSource.getConnection();
+					PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							_db.buildSQL(
+								"select configurationId, dictionary from " +
+									"Configuration_"),
+							ResultSet.TYPE_FORWARD_ONLY,
+							ResultSet.CONCUR_READ_ONLY);
+					ResultSet resultSet = preparedStatement.executeQuery()) {
 
-			while (resultSet.next()) {
-				String pid = resultSet.getString(1);
+					while (resultSet.next()) {
+						String pid = resultSet.getString(1);
 
-				Dictionary<Object, Object> dictionary = _verifyDictionary(
-					pid, resultSet.getString(2));
+						Dictionary<Object, Object> dictionary =
+							_verifyDictionary(pid, resultSet.getString(2));
 
-				if (dictionary != null) {
-					overridePropertiesMap.remove(pid);
+						if (dictionary != null) {
+							overridePropertiesMap.remove(pid);
 
-					_dictionaries.put(
-						pid, _overrideDictionary(pid, dictionary));
+							_dictionaries.put(
+								pid, _overrideDictionary(pid, dictionary));
+						}
+					}
 				}
-			}
-		}
+			});
 
 		overridePropertiesMap.forEach(
 			(key, value) -> _dictionaries.put(

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/registry/ConfigurationPersistenceUpgradeStepRegistrator.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/registry/ConfigurationPersistenceUpgradeStepRegistrator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.configuration.persistence.internal.upgrade.registry;
 
+import com.liferay.portal.configuration.persistence.internal.upgrade.v2_0_0.ConfigurationUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -47,6 +48,8 @@ public class ConfigurationPersistenceUpgradeStepRegistrator
 			"1.0.2", "1.0.3",
 			new com.liferay.portal.configuration.persistence.internal.upgrade.
 				v1_0_3.ConfigurationUpgradeProcess(_configurationAdmin));
+
+		registry.register("1.0.3", "2.0.0", new ConfigurationUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
@@ -1,0 +1,303 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.configuration.persistence.internal.upgrade.v2_0_0;
+
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.db.partition.DBPartitionUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.util.PortalInstances;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.Dictionary;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
+
+/**
+ * @author Luis Ortiz
+ */
+public class ConfigurationUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (PortalInstances.getDefaultCompanyId() ==
+				CompanyThreadLocal.getCompanyId()) {
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select configurationId, dictionary from " +
+							"Configuration_");
+				ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				while (resultSet.next()) {
+					String pid = resultSet.getString(1);
+
+					String dictionaryString = resultSet.getString(2);
+
+					ScopedConfig scopedConfig = _getScopedConfig(
+						dictionaryString, pid);
+
+					if ((scopedConfig != null) &&
+						!_configApplies(scopedConfig)) {
+
+						_configurations.add(scopedConfig);
+
+						_removeConfiguration(scopedConfig.getKey());
+					}
+				}
+			}
+
+			long[] companyIds = PortalInstances.getCompanyIds();
+
+			_atomicInteger.set(companyIds.length - 1);
+
+			return;
+		}
+
+		DBPartitionUtil.replaceByTable(connection, false, "Configuration_");
+
+		for (ScopedConfig scopedConfig : _configurations) {
+			if (_configApplies(scopedConfig)) {
+				_insertConfiguration(
+					scopedConfig.getDictionary(), scopedConfig.getKey());
+
+				String scopeValue = scopedConfig.getScope(
+				).getValue();
+
+				if (scopeValue.equals(
+						ExtendedObjectClassDefinition.Scope.COMPANY.
+							getValue()) ||
+					scopeValue.equals(
+						ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
+
+					_configurations.remove(scopedConfig);
+				}
+			}
+		}
+
+		int remainingCompanies = _atomicInteger.decrementAndGet();
+
+		if (remainingCompanies == 0) {
+			for (ScopedConfig scopedConfig : _configurations) {
+				String scopeValue = scopedConfig.getScope(
+				).getValue();
+
+				if (scopeValue.equals(
+						ExtendedObjectClassDefinition.Scope.COMPANY.
+							getValue())) {
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Configuration with pid ",
+								scopedConfig.getKey(),
+								" applicable to company ",
+								(String)scopedConfig.getScopePK(),
+								" has been removed as the company does not ",
+								"exists"));
+					}
+				}
+
+				if (scopeValue.equals(
+						ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Configuration with pid ",
+								scopedConfig.getKey(), " applicable to group ",
+								(String)scopedConfig.getScopePK(),
+								" has been removed as the group does not ",
+								"exists"));
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	protected boolean isSkipUpgradeProcess() {
+		if (!DBPartition.isPartitionEnabled()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _configApplies(ScopedConfig scopedConfig)
+		throws SQLException {
+
+		String configScopeValue = scopedConfig.getScope(
+		).getValue();
+
+		if (configScopeValue.equals(
+				ExtendedObjectClassDefinition.Scope.COMPANY.getValue())) {
+
+			if (CompanyThreadLocal.getCompanyId() ==
+					(long)scopedConfig.getScopePK()) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		if (configScopeValue.equals(
+				ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select companyId from Group_ where groupId = ?")) {
+
+				preparedStatement.setLong(1, (long)scopedConfig.getScopePK());
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					if (resultSet.next()) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		if (configScopeValue.equals(
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+					getValue())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private ScopedConfig _getScopedConfig(String dictionary, String key)
+		throws IOException {
+
+		Dictionary<Object, Object> dictionaryMap = ConfigurationHandler.read(
+			new UnsyncByteArrayInputStream(
+				dictionary.getBytes(StringPool.UTF8)));
+
+		Object value = dictionaryMap.get(
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfig(
+				dictionary, key, (long)value,
+				ExtendedObjectClassDefinition.Scope.COMPANY);
+		}
+
+		value = dictionaryMap.get(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfig(
+				dictionary, key, (long)value,
+				ExtendedObjectClassDefinition.Scope.GROUP);
+		}
+
+		value = dictionaryMap.get(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfig(
+				dictionary, key, (String)value,
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE);
+		}
+
+		return null;
+	}
+
+	private void _insertConfiguration(String dictionary, String pid)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_db.buildSQL(
+					"insert into Configuration_ (configurationId, dictionary" +
+						") values (?, ?)"))) {
+
+			preparedStatement.setString(1, pid);
+			preparedStatement.setString(2, dictionary);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private void _removeConfiguration(String pid)
+		throws IOException, SQLException {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_db.buildSQL(
+					"delete from Configuration_ where configurationId = ?"))) {
+
+			preparedStatement.setString(1, pid);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ConfigurationUpgradeProcess.class);
+
+	private static final AtomicInteger _atomicInteger = new AtomicInteger();
+	private static final CopyOnWriteArrayList<ScopedConfig> _configurations =
+		new CopyOnWriteArrayList<>();
+
+	private final DB _db = DBManagerUtil.getDB();
+
+	private class ScopedConfig {
+
+		public ScopedConfig(
+			String dictionary, String key, Serializable scopePK,
+			ExtendedObjectClassDefinition.Scope scope) {
+
+			_dictionary = dictionary;
+			_key = key;
+			_scopePK = scopePK;
+			_scope = scope;
+		}
+
+		public String getDictionary() {
+			return _dictionary;
+		}
+
+		public String getKey() {
+			return _key;
+		}
+
+		public ExtendedObjectClassDefinition.Scope getScope() {
+			return _scope;
+		}
+
+		public Serializable getScopePK() {
+			return _scopePK;
+		}
+
+		private final String _dictionary;
+		private final String _key;
+		private final ExtendedObjectClassDefinition.Scope _scope;
+		private final Serializable _scopePK;
+
+	}
+
+}

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
@@ -10,23 +10,21 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.db.partition.DBPartitionUtil;
-import com.liferay.portal.kernel.dao.db.DB;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.util.PortalInstances;
 
-import java.io.IOException;
 import java.io.Serializable;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 
 import java.util.Dictionary;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -49,19 +47,30 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					String pid = resultSet.getString(1);
+					ScopeConfiguration scopeConfiguration =
+						_getScopeConfiguration(
+							resultSet.getString(1), resultSet.getString(2));
 
-					String dictionaryString = resultSet.getString(2);
+					if (scopeConfiguration != null) {
+						if (Objects.equals(
+								scopeConfiguration.getScope(),
+								ExtendedObjectClassDefinition.Scope.
+									PORTLET_INSTANCE)) {
 
-					ScopedConfig scopedConfig = _getScopedConfig(
-						dictionaryString, pid);
+							_scopeConfigurations.add(scopeConfiguration);
 
-					if ((scopedConfig != null) &&
-						!_configApplies(scopedConfig)) {
+							continue;
+						}
 
-						_configurations.add(scopedConfig);
+						if (!_isApplicable(
+								scopeConfiguration,
+								PortalInstances.getDefaultCompanyId())) {
 
-						_removeConfiguration(scopedConfig.getKey());
+							_scopeConfigurations.add(scopeConfiguration);
+
+							_removeConfiguration(
+								scopeConfiguration.getConfigurationId());
+						}
 					}
 				}
 			}
@@ -75,60 +84,51 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 
 		DBPartitionUtil.replaceByTable(connection, false, "Configuration_");
 
-		for (ScopedConfig scopedConfig : _configurations) {
-			if (_configApplies(scopedConfig)) {
+		for (ScopeConfiguration scopeConfiguration : _scopeConfigurations) {
+			if (_isApplicable(
+					scopeConfiguration, CompanyThreadLocal.getCompanyId())) {
+
 				_insertConfiguration(
-					scopedConfig.getDictionary(), scopedConfig.getKey());
+					scopeConfiguration.getConfigurationId(),
+					scopeConfiguration.getDictionary());
 
-				String scopeValue = scopedConfig.getScope(
-				).getValue();
+				if (!Objects.equals(
+						scopeConfiguration.getScope(),
+						ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE)) {
 
-				if (scopeValue.equals(
-						ExtendedObjectClassDefinition.Scope.COMPANY.
-							getValue()) ||
-					scopeValue.equals(
-						ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
-
-					_configurations.remove(scopedConfig);
+					_scopeConfigurations.remove(scopeConfiguration);
 				}
 			}
 		}
 
 		int remainingCompanies = _atomicInteger.decrementAndGet();
 
-		if (remainingCompanies == 0) {
-			for (ScopedConfig scopedConfig : _configurations) {
-				String scopeValue = scopedConfig.getScope(
-				).getValue();
+		if ((remainingCompanies == 0) && _log.isWarnEnabled()) {
+			for (ScopeConfiguration scopeConfiguration : _scopeConfigurations) {
+				if (Objects.equals(
+						scopeConfiguration.getScope(),
+						ExtendedObjectClassDefinition.Scope.COMPANY)) {
 
-				if (scopeValue.equals(
-						ExtendedObjectClassDefinition.Scope.COMPANY.
-							getValue())) {
-
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							StringBundler.concat(
-								"Configuration with pid ",
-								scopedConfig.getKey(),
-								" applicable to company ",
-								(String)scopedConfig.getScopePK(),
-								" has been removed as the company does not ",
-								"exists"));
-					}
+					_log.warn(
+						StringBundler.concat(
+							"Company scope configuration with ID ",
+							scopeConfiguration.getConfigurationId(),
+							" has been removed because the company ID ",
+							scopeConfiguration.getScopePK(),
+							"does not exists"));
 				}
 
-				if (scopeValue.equals(
-						ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
+				if (Objects.equals(
+						scopeConfiguration.getScope(),
+						ExtendedObjectClassDefinition.Scope.GROUP)) {
 
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							StringBundler.concat(
-								"Configuration with pid ",
-								scopedConfig.getKey(), " applicable to group ",
-								(String)scopedConfig.getScopePK(),
-								" has been removed as the group does not ",
-								"exists"));
-					}
+					_log.warn(
+						StringBundler.concat(
+							"Group scope configuration with ID ",
+							scopeConfiguration.getConfigurationId(),
+							" has been removed because the group ID ",
+							scopeConfiguration.getScopePK(),
+							"does not exists"));
 				}
 			}
 		}
@@ -143,32 +143,84 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 		return false;
 	}
 
-	private boolean _configApplies(ScopedConfig scopedConfig)
-		throws SQLException {
+	private ScopeConfiguration _getScopeConfiguration(
+			String configurationId, String dictionary)
+		throws Exception {
 
-		String configScopeValue = scopedConfig.getScope(
-		).getValue();
+		Dictionary<String, String> dictionaryMap = ConfigurationHandler.read(
+			new UnsyncByteArrayInputStream(
+				dictionary.getBytes(StringPool.UTF8)));
 
-		if (configScopeValue.equals(
-				ExtendedObjectClassDefinition.Scope.COMPANY.getValue())) {
+		String value = dictionaryMap.get(
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
 
-			if (CompanyThreadLocal.getCompanyId() ==
-					(long)scopedConfig.getScopePK()) {
+		if (value != null) {
+			return new ScopeConfiguration(
+				configurationId, dictionary, GetterUtil.getLong(value),
+				ExtendedObjectClassDefinition.Scope.COMPANY);
+		}
 
+		value = dictionaryMap.get(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey());
+
+		if (value != null) {
+			return new ScopeConfiguration(
+				configurationId, dictionary, GetterUtil.getLong(value),
+				ExtendedObjectClassDefinition.Scope.GROUP);
+		}
+
+		value = dictionaryMap.get(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey());
+
+		if (value != null) {
+			return new ScopeConfiguration(
+				configurationId, dictionary, value,
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE);
+		}
+
+		return null;
+	}
+
+	private void _insertConfiguration(String configurationId, String dictionary)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"insert into Configuration_ (configurationId, dictionary" +
+					") values (?, ?)")) {
+
+			preparedStatement.setString(1, configurationId);
+			preparedStatement.setString(2, dictionary);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private boolean _isApplicable(
+			ScopeConfiguration scopeConfiguration, long companyId)
+		throws Exception {
+
+		if (Objects.equals(
+				scopeConfiguration.getScope(),
+				ExtendedObjectClassDefinition.Scope.COMPANY)) {
+
+			if (companyId == (long)scopeConfiguration.getScopePK()) {
 				return true;
 			}
 
 			return false;
 		}
 
-		if (configScopeValue.equals(
-				ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
+		if (Objects.equals(
+				scopeConfiguration.getScope(),
+				ExtendedObjectClassDefinition.Scope.GROUP)) {
 
 			try (PreparedStatement preparedStatement =
 					connection.prepareStatement(
-						"select companyId from Group_ where groupId = ?")) {
+						"select groupId from Group_ where groupId = ?")) {
 
-				preparedStatement.setLong(1, (long)scopedConfig.getScopePK());
+				preparedStatement.setLong(
+					1, (long)scopeConfiguration.getScopePK());
 
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
 					if (resultSet.next()) {
@@ -180,77 +232,14 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 			return false;
 		}
 
-		if (configScopeValue.equals(
-				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
-					getValue())) {
-
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 
-	private ScopedConfig _getScopedConfig(String dictionary, String key)
-		throws IOException {
-
-		Dictionary<Object, Object> dictionaryMap = ConfigurationHandler.read(
-			new UnsyncByteArrayInputStream(
-				dictionary.getBytes(StringPool.UTF8)));
-
-		Object value = dictionaryMap.get(
-			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
-
-		if (value != null) {
-			return new ScopedConfig(
-				dictionary, key, (long)value,
-				ExtendedObjectClassDefinition.Scope.COMPANY);
-		}
-
-		value = dictionaryMap.get(
-			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey());
-
-		if (value != null) {
-			return new ScopedConfig(
-				dictionary, key, (long)value,
-				ExtendedObjectClassDefinition.Scope.GROUP);
-		}
-
-		value = dictionaryMap.get(
-			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
-				getPropertyKey());
-
-		if (value != null) {
-			return new ScopedConfig(
-				dictionary, key, (String)value,
-				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE);
-		}
-
-		return null;
-	}
-
-	private void _insertConfiguration(String dictionary, String pid)
-		throws Exception {
-
+	private void _removeConfiguration(String configurationId) throws Exception {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_db.buildSQL(
-					"insert into Configuration_ (configurationId, dictionary" +
-						") values (?, ?)"))) {
+				"delete from Configuration_ where configurationId = ?")) {
 
-			preparedStatement.setString(1, pid);
-			preparedStatement.setString(2, dictionary);
-
-			preparedStatement.executeUpdate();
-		}
-	}
-
-	private void _removeConfiguration(String pid)
-		throws IOException, SQLException {
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_db.buildSQL(
-					"delete from Configuration_ where configurationId = ?"))) {
-
-			preparedStatement.setString(1, pid);
+			preparedStatement.setString(1, configurationId);
 
 			preparedStatement.executeUpdate();
 		}
@@ -260,43 +249,41 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 		ConfigurationUpgradeProcess.class);
 
 	private static final AtomicInteger _atomicInteger = new AtomicInteger();
-	private static final CopyOnWriteArrayList<ScopedConfig> _configurations =
-		new CopyOnWriteArrayList<>();
+	private static final CopyOnWriteArrayList<ScopeConfiguration>
+		_scopeConfigurations = new CopyOnWriteArrayList<>();
 
-	private final DB _db = DBManagerUtil.getDB();
+	private class ScopeConfiguration {
 
-	private class ScopedConfig {
-
-		public ScopedConfig(
-			String dictionary, String key, Serializable scopePK,
+		public ScopeConfiguration(
+			String configurationId, String dictionary, Serializable scopePK,
 			ExtendedObjectClassDefinition.Scope scope) {
 
+			_configurationId = configurationId;
 			_dictionary = dictionary;
-			_key = key;
 			_scopePK = scopePK;
 			_scope = scope;
+		}
+
+		public String getConfigurationId() {
+			return _configurationId;
 		}
 
 		public String getDictionary() {
 			return _dictionary;
 		}
 
-		public String getKey() {
-			return _key;
-		}
-
 		public ExtendedObjectClassDefinition.Scope getScope() {
 			return _scope;
 		}
 
-		public Serializable getScopePK() {
+		public Object getScopePK() {
 			return _scopePK;
 		}
 
+		private final String _configurationId;
 		private final String _dictionary;
-		private final String _key;
 		private final ExtendedObjectClassDefinition.Scope _scope;
-		private final Serializable _scopePK;
+		private final Object _scopePK;
 
 	}
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
@@ -11,12 +11,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.Serializable;
 
@@ -37,7 +37,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (PortalInstances.getDefaultCompanyId() ==
+		if (PortalInstancePool.getDefaultCompanyId() ==
 				CompanyThreadLocal.getCompanyId()) {
 
 			try (PreparedStatement preparedStatement =
@@ -64,7 +64,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 
 						if (!_isApplicable(
 								scopeConfiguration,
-								PortalInstances.getDefaultCompanyId())) {
+								PortalInstancePool.getDefaultCompanyId())) {
 
 							_scopeConfigurations.add(scopeConfiguration);
 
@@ -75,7 +75,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 				}
 			}
 
-			long[] companyIds = PortalInstances.getCompanyIds();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			_atomicInteger.set(companyIds.length - 1);
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationUpgradeProcess.java
@@ -115,7 +115,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 							scopeConfiguration.getConfigurationId(),
 							" has been removed because the company ID ",
 							scopeConfiguration.getScopePK(),
-							"does not exists"));
+							" does not exists"));
 				}
 
 				if (Objects.equals(
@@ -128,7 +128,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 							scopeConfiguration.getConfigurationId(),
 							" has been removed because the group ID ",
 							scopeConfiguration.getScopePK(),
-							"does not exists"));
+							" does not exists"));
 				}
 			}
 		}
@@ -151,7 +151,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 			new UnsyncByteArrayInputStream(
 				dictionary.getBytes(StringPool.UTF8)));
 
-		String value = dictionaryMap.get(
+		Object value = dictionaryMap.get(
 			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
 
 		if (value != null) {
@@ -175,7 +175,7 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 
 		if (value != null) {
 			return new ScopeConfiguration(
-				configurationId, dictionary, value,
+				configurationId, dictionary, GetterUtil.getString(value),
 				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE);
 		}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/build.gradle
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/build.gradle
@@ -4,10 +4,12 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.log", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-file-install:portal-file-install-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-io")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-memory")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/activator/FileInstallImplBundleActivator.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/activator/FileInstallImplBundleActivator.java
@@ -16,11 +16,7 @@ import com.liferay.portal.kernel.util.ModuleFrameworkPropsValues;
 import java.io.File;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-
-import javax.sql.DataSource;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -43,20 +39,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 		_jarFileInstallerServiceRegistration = _bundleContext.registerService(
 			FileInstaller.class, new DefaultJarInstaller(), null);
 
-		Collection<ServiceReference<DataSource>> serviceReferences =
-			bundleContext.getServiceReferences(
-				DataSource.class, "(bean.id=liferayDataSource)");
-
-		if ((serviceReferences == null) || serviceReferences.isEmpty()) {
-			throw new IllegalStateException(
-				"Liferay data source is not available");
-		}
-
-		Iterator<ServiceReference<DataSource>> iterator =
-			serviceReferences.iterator();
-
-		_serviceReference = iterator.next();
-
 		_serviceTracker = new ServiceTracker<>(
 			bundleContext, ConfigurationAdmin.class.getName(),
 			new ServiceTrackerCustomizer
@@ -74,7 +56,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 							FileInstaller.class.getName(),
 							new ConfigurationFileInstaller(
 								configurationAdmin,
-								_bundleContext.getService(_serviceReference),
 								ModuleFrameworkPropsValues.
 									MODULE_FRAMEWORK_FILE_INSTALL_CONFIG_ENCODING),
 							null),
@@ -124,10 +105,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 		_serviceTracker.close();
 
 		_jarFileInstallerServiceRegistration.unregister();
-
-		if (_serviceReference != null) {
-			bundleContext.ungetService(_serviceReference);
-		}
 	}
 
 	public void updateChecksum(File file) {
@@ -140,7 +117,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 	private DirectoryWatcher _directoryWatcher;
 	private ServiceRegistration<FileInstaller>
 		_jarFileInstallerServiceRegistration;
-	private ServiceReference<DataSource> _serviceReference;
 	private ServiceTracker<ConfigurationAdmin, List<ServiceRegistration<?>>>
 		_serviceTracker;
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/activator/FileInstallImplBundleActivator.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/activator/FileInstallImplBundleActivator.java
@@ -16,7 +16,11 @@ import com.liferay.portal.kernel.util.ModuleFrameworkPropsValues;
 import java.io.File;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+
+import javax.sql.DataSource;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -39,6 +43,20 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 		_jarFileInstallerServiceRegistration = _bundleContext.registerService(
 			FileInstaller.class, new DefaultJarInstaller(), null);
 
+		Collection<ServiceReference<DataSource>> serviceReferences =
+			bundleContext.getServiceReferences(
+				DataSource.class, "(bean.id=liferayDataSource)");
+
+		if ((serviceReferences == null) || serviceReferences.isEmpty()) {
+			throw new IllegalStateException(
+				"Liferay data source is not available");
+		}
+
+		Iterator<ServiceReference<DataSource>> iterator =
+			serviceReferences.iterator();
+
+		_serviceReference = iterator.next();
+
 		_serviceTracker = new ServiceTracker<>(
 			bundleContext, ConfigurationAdmin.class.getName(),
 			new ServiceTrackerCustomizer
@@ -56,6 +74,7 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 							FileInstaller.class.getName(),
 							new ConfigurationFileInstaller(
 								configurationAdmin,
+								_bundleContext.getService(_serviceReference),
 								ModuleFrameworkPropsValues.
 									MODULE_FRAMEWORK_FILE_INSTALL_CONFIG_ENCODING),
 							null),
@@ -105,6 +124,10 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 		_serviceTracker.close();
 
 		_jarFileInstallerServiceRegistration.unregister();
+
+		if (_serviceReference != null) {
+			bundleContext.ungetService(_serviceReference);
+		}
 	}
 
 	public void updateChecksum(File file) {
@@ -117,6 +140,7 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 	private DirectoryWatcher _directoryWatcher;
 	private ServiceRegistration<FileInstaller>
 		_jarFileInstallerServiceRegistration;
+	private ServiceReference<DataSource> _serviceReference;
 	private ServiceTracker<ConfigurationAdmin, List<ServiceRegistration<?>>>
 		_serviceTracker;
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -16,9 +16,11 @@ import com.liferay.portal.file.install.internal.Util;
 import com.liferay.portal.file.install.properties.ConfigurationProperties;
 import com.liferay.portal.file.install.properties.ConfigurationPropertiesFactory;
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
@@ -26,10 +28,6 @@ import com.liferay.portal.util.PropsValues;
 import java.io.File;
 
 import java.net.URL;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -96,33 +94,11 @@ public class ConfigurationFileInstaller implements FileInstaller {
 
 		String[] pid = _parsePid(file.getName());
 
-		SafeCloseable safeCloseable = null;
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(
+					_getCompanyId(
+						_getScope(dictionary), dictionary, file.getName()))) {
 
-		if (DBPartition.isPartitionEnabled()) {
-			ExtendedObjectClassDefinition.Scope configurationScope =
-				_getConfigurationScope(dictionary);
-
-			if (Objects.equals(configurationScope.getValue(), "group") ||
-				Objects.equals(
-					configurationScope.getValue(), "portlet-instance")) {
-
-				throw new Exception(
-					StringBundler.concat(
-						"When Database Partitioning is enabled it is not ",
-						"possible to load ", configurationScope.getValue(),
-						" scoped configurations from config files. Please set ",
-						"those configurations through the UI. File ",
-						file.getName(), " has not been processed"));
-			}
-
-			if (Objects.equals(configurationScope.getValue(), "company")) {
-				safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
-					_getCompanyIdFromConfiguration(
-						configurationScope, dictionary, file.getName()));
-			}
-		}
-
-		try {
 			Configuration configuration = _getConfiguration(
 				file.getName(), pid[0], pid[1]);
 
@@ -222,11 +198,6 @@ public class ConfigurationFileInstaller implements FileInstaller {
 				}
 			}
 		}
-		finally {
-			if (safeCloseable != null) {
-				safeCloseable.close();
-			}
-		}
 
 		return null;
 	}
@@ -251,31 +222,13 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		Configuration configuration = _getConfiguration(
 			file.getName(), pid[0], pid[1]);
 
-		SafeCloseable safeCloseable = null;
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(
+					_getCompanyId(
+						ExtendedObjectClassDefinition.Scope.COMPANY,
+						configuration.getProperties(), file.getName()))) {
 
-		if (DBPartition.isPartitionEnabled()) {
-			Dictionary<String, Object> dictionary =
-				configuration.getProperties();
-
-			if (dictionary != null) {
-				ExtendedObjectClassDefinition.Scope configurationScope =
-					_getConfigurationScope(dictionary);
-
-				if (Objects.equals(configurationScope.getValue(), "company")) {
-					safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
-						_getCompanyIdFromConfiguration(
-							configurationScope, dictionary, file.getName()));
-				}
-			}
-		}
-
-		try {
 			configuration.delete();
-		}
-		finally {
-			if (safeCloseable != null) {
-				safeCloseable.close();
-			}
 		}
 	}
 
@@ -334,55 +287,49 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		return null;
 	}
 
-	private long _getCompanyIdFromConfiguration(
-			ExtendedObjectClassDefinition.Scope scope,
-			Dictionary<String, Object> dictionary, String fileName)
-		throws Exception {
+	private Long _getCompanyId(
+		ExtendedObjectClassDefinition.Scope scope,
+		Dictionary<String, Object> dictionary, String fileName) {
 
-		Object value = dictionary.get(scope.getPropertyKey());
+		if (!DBPartition.isPartitionEnabled() ||
+			(scope != ExtendedObjectClassDefinition.Scope.COMPANY) ||
+			(dictionary == null)) {
 
-		if (value != null) {
-			try (Connection connection = _dataSource.getConnection();
-				PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						_db.buildSQL(
-							"select companyId from Company where companyId = " +
-								"?"))) {
-
-				preparedStatement.setLong(1, (long)value);
-
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					if (resultSet.next()) {
-						return resultSet.getLong(1);
-					}
-				}
-			}
+			return 0L;
 		}
 
-		value = dictionary.get(scope.getPortablePropertyKey());
+		Long companyId = (Long)dictionary.get(scope.getPropertyKey());
 
-		if (value != null) {
-			try (Connection connection = _dataSource.getConnection();
-				PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						_db.buildSQL(
-							"select companyId from Company where webId = ?"))) {
+		if (companyId != null) {
+			if (!ArrayUtil.contains(
+					PortalInstancePool.getCompanyIds(), companyId)) {
 
-				preparedStatement.setString(1, (String)value);
-
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					if (resultSet.next()) {
-						return resultSet.getLong(1);
-					}
-				}
+				throw new IllegalArgumentException(
+					StringBundler.concat(
+						"Unable to process ", fileName, ": company ID ",
+						companyId, " does not exist"));
 			}
+
+			return companyId;
 		}
 
-		throw new Exception(
-			StringBundler.concat(
-				"Company for the scoped indicated in configuration file ",
-				fileName,
-				" has not been found. Configuration has not been applied."));
+		String webId = (String)dictionary.get(scope.getPortablePropertyKey());
+
+		if (webId != null) {
+			try {
+				companyId = PortalInstancePool.getCompanyId(webId);
+			}
+			catch (IllegalArgumentException illegalArgumentException) {
+				throw new IllegalArgumentException(
+					StringBundler.concat(
+						"Unable to process ", fileName, ": ",
+						illegalArgumentException.getMessage()));
+			}
+
+			return companyId;
+		}
+
+		return 0L;
 	}
 
 	private Configuration _getConfiguration(
@@ -403,22 +350,35 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		return _configurationAdmin.getConfiguration(pid, StringPool.QUESTION);
 	}
 
-	private ExtendedObjectClassDefinition.Scope _getConfigurationScope(
+	private ExtendedObjectClassDefinition.Scope _getScope(
 		Dictionary<String, Object> dictionary) {
+
+		if (!DBPartition.isPartitionEnabled()) {
+			return null;
+		}
 
 		for (ExtendedObjectClassDefinition.Scope scope :
 				ExtendedObjectClassDefinition.Scope.values()) {
 
-			String key = scope.getPortablePropertyKey();
+			for (String key :
+					new String[] {
+						scope.getPropertyKey(), scope.getPortablePropertyKey()
+					}) {
 
-			if ((key != null) && (dictionary.get(key) != null)) {
-				return scope;
-			}
+				if ((key != null) && (dictionary.get(key) != null)) {
+					if (!scope.equals(
+							ExtendedObjectClassDefinition.Scope.COMPANY)) {
 
-			key = scope.getPropertyKey();
+						throw new UnsupportedOperationException(
+							StringBundler.concat(
+								StringUtil.upperCaseFirstLetter(
+									scope.getValue()),
+								" scoped configuration files are not ",
+								"supported with Database Partition"));
+					}
 
-			if ((key != null) && (dictionary.get(key) != null)) {
-				return scope;
+					return scope;
+				}
 			}
 		}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -263,13 +263,15 @@ public class ConfigurationFileInstaller implements FileInstaller {
 			Dictionary<String, Object> dictionary =
 				configuration.getProperties();
 
-			ExtendedObjectClassDefinition.Scope configurationScope =
-				_getConfigurationScope(dictionary);
+			if (dictionary != null) {
+				ExtendedObjectClassDefinition.Scope configurationScope =
+					_getConfigurationScope(dictionary);
 
-			if (Objects.equals(configurationScope.getValue(), "company")) {
-				safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
-					_getCompanyIdFromConfiguration(
-						configurationScope, dictionary, file.getName()));
+				if (Objects.equals(configurationScope.getValue(), "company")) {
+					safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
+						_getCompanyIdFromConfiguration(
+							configurationScope, dictionary, file.getName()));
+				}
 			}
 		}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -28,6 +28,8 @@ import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.sql.DataSource;
+
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -38,9 +40,11 @@ import org.osgi.service.cm.ConfigurationAdmin;
 public class ConfigurationFileInstaller implements FileInstaller {
 
 	public ConfigurationFileInstaller(
-		ConfigurationAdmin configurationAdmin, String encoding) {
+		ConfigurationAdmin configurationAdmin, DataSource dataSource,
+		String encoding) {
 
 		_configurationAdmin = configurationAdmin;
+		_dataSource = dataSource;
 		_encoding = encoding;
 
 		_configsDirPath = Util.getFilePath(
@@ -312,6 +316,7 @@ public class ConfigurationFileInstaller implements FileInstaller {
 
 	private final String _configsDirPath;
 	private final ConfigurationAdmin _configurationAdmin;
+	private final DataSource _dataSource;
 	private final String _encoding;
 
 }

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -5,16 +5,22 @@
 
 package com.liferay.portal.file.install.internal.configuration;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.file.install.FileInstaller;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.file.install.internal.Util;
 import com.liferay.portal.file.install.properties.ConfigurationProperties;
 import com.liferay.portal.file.install.properties.ConfigurationPropertiesFactory;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
@@ -22,6 +28,10 @@ import com.liferay.portal.util.PropsValues;
 import java.io.File;
 
 import java.net.URL;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -92,99 +102,135 @@ public class ConfigurationFileInstaller implements FileInstaller {
 
 		String[] pid = _parsePid(file.getName());
 
-		Configuration configuration = _getConfiguration(
-			file.getName(), pid[0], pid[1]);
+		SafeCloseable safeCloseable = null;
 
-		Set<Configuration.ConfigurationAttribute> configurationAttributes =
-			configuration.getAttributes();
+		if (DBPartition.isPartitionEnabled()) {
+			ExtendedObjectClassDefinition.Scope configurationScope =
+				_getConfigurationScope(dictionary);
 
-		if (configurationAttributes.contains(
-				Configuration.ConfigurationAttribute.READ_ONLY)) {
-
-			configuration.removeAttributes(
-				Configuration.ConfigurationAttribute.READ_ONLY);
-		}
-
-		Dictionary<String, Object> properties = configuration.getProperties();
-
-		Dictionary<String, Object> old = null;
-
-		if (properties != null) {
-			old = new HashMapDictionary<>();
-
-			Enumeration<String> enumeration = properties.keys();
-
-			while (enumeration.hasMoreElements()) {
-				String key = enumeration.nextElement();
-
-				old.put(key, properties.get(key));
-			}
-		}
-
-		String oldFileName = null;
-
-		if (old != null) {
-			oldFileName = (String)old.remove(
-				FileInstallConstants.FELIX_FILE_INSTALL_FILENAME);
-
-			old.remove(Constants.SERVICE_PID);
-			old.remove(ConfigurationAdmin.SERVICE_FACTORYPID);
-
-			if ((dictionary.get(ConfigurationAdmin.SERVICE_BUNDLELOCATION) ==
-					null) &&
+			if (Objects.equals(configurationScope.getValue(), "group") ||
 				Objects.equals(
-					StringPool.QUESTION,
-					old.get(ConfigurationAdmin.SERVICE_BUNDLELOCATION))) {
+					configurationScope.getValue(), "portlet-instance")) {
 
-				old.remove(ConfigurationAdmin.SERVICE_BUNDLELOCATION);
+				throw new Exception(
+					StringBundler.concat(
+						"When Database Partitioning is enabled it is not ",
+						"possible to load ", configurationScope.getValue(),
+						" scoped configurations from config files. Please set ",
+						"those configurations through the UI. File ",
+						file.getName(), " has not been processed"));
+			}
+
+			if (Objects.equals(configurationScope.getValue(), "company")) {
+				safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
+					_getCompanyIdFromConfiguration(
+						configurationScope, dictionary, file.getName()));
 			}
 		}
 
-		String currentFileName = file.getName();
+		try {
+			Configuration configuration = _getConfiguration(
+				file.getName(), pid[0], pid[1]);
 
-		if (!_equals(dictionary, old) ||
-			!Objects.equals(oldFileName, currentFileName) ||
-			configurationAttributes.contains(
-				Configuration.ConfigurationAttribute.READ_ONLY) ||
-			!file.canWrite()) {
+			Set<Configuration.ConfigurationAttribute> configurationAttributes =
+				configuration.getAttributes();
 
-			dictionary.put(
-				FileInstallConstants.FELIX_FILE_INSTALL_FILENAME,
-				currentFileName);
+			if (configurationAttributes.contains(
+					Configuration.ConfigurationAttribute.READ_ONLY)) {
 
-			String logString = StringPool.BLANK;
-
-			if (pid[1] != null) {
-				logString = StringPool.TILDE + pid[1];
+				configuration.removeAttributes(
+					Configuration.ConfigurationAttribute.READ_ONLY);
 			}
 
-			if (old == null) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Creating configuration from ", pid[0], logString,
-							".config"));
-				}
-			}
-			else {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Updating configuration from ", pid[0], logString,
-							".config"));
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			Dictionary<String, Object> old = null;
+
+			if (properties != null) {
+				old = new HashMapDictionary<>();
+
+				Enumeration<String> enumeration = properties.keys();
+
+				while (enumeration.hasMoreElements()) {
+					String key = enumeration.nextElement();
+
+					old.put(key, properties.get(key));
 				}
 			}
 
-			configuration.updateIfDifferent(dictionary);
+			String oldFileName = null;
 
-			if (!file.canWrite()) {
-				try {
-					configuration.addAttributes(
-						Configuration.ConfigurationAttribute.READ_ONLY);
+			if (old != null) {
+				oldFileName = (String)old.remove(
+					FileInstallConstants.FELIX_FILE_INSTALL_FILENAME);
+
+				old.remove(Constants.SERVICE_PID);
+				old.remove(ConfigurationAdmin.SERVICE_FACTORYPID);
+
+				Object bundleLocation = dictionary.get(
+					ConfigurationAdmin.SERVICE_BUNDLELOCATION);
+
+				if ((bundleLocation == null) &&
+					Objects.equals(
+						StringPool.QUESTION,
+						old.get(ConfigurationAdmin.SERVICE_BUNDLELOCATION))) {
+
+					old.remove(ConfigurationAdmin.SERVICE_BUNDLELOCATION);
 				}
-				catch (Throwable throwable) {
-					_log.error(throwable);
+			}
+
+			String currentFileName = file.getName();
+
+			if (!_equals(dictionary, old) ||
+				!Objects.equals(oldFileName, currentFileName) ||
+				configurationAttributes.contains(
+					Configuration.ConfigurationAttribute.READ_ONLY) ||
+				!file.canWrite()) {
+
+				dictionary.put(
+					FileInstallConstants.FELIX_FILE_INSTALL_FILENAME,
+					currentFileName);
+
+				String logString = StringPool.BLANK;
+
+				if (pid[1] != null) {
+					logString = StringPool.TILDE + pid[1];
 				}
+
+				if (old == null) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Creating configuration from ", pid[0],
+								logString, ".config"));
+					}
+				}
+				else {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Updating configuration from ", pid[0],
+								logString, ".config"));
+					}
+				}
+
+				configuration.updateIfDifferent(dictionary);
+
+				if (!file.canWrite()) {
+					try {
+						configuration.addAttributes(
+							Configuration.ConfigurationAttribute.READ_ONLY);
+					}
+					catch (Throwable throwable) {
+						_log.error(throwable);
+					}
+				}
+			}
+		}
+		finally {
+			if (safeCloseable != null) {
+				safeCloseable.close();
 			}
 		}
 
@@ -211,7 +257,30 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		Configuration configuration = _getConfiguration(
 			file.getName(), pid[0], pid[1]);
 
-		configuration.delete();
+		SafeCloseable safeCloseable = null;
+
+		if (DBPartition.isPartitionEnabled()) {
+			Dictionary<String, Object> dictionary =
+				configuration.getProperties();
+
+			ExtendedObjectClassDefinition.Scope configurationScope =
+				_getConfigurationScope(dictionary);
+
+			if (Objects.equals(configurationScope.getValue(), "company")) {
+				safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
+					_getCompanyIdFromConfiguration(
+						configurationScope, dictionary, file.getName()));
+			}
+		}
+
+		try {
+			configuration.delete();
+		}
+		finally {
+			if (safeCloseable != null) {
+				safeCloseable.close();
+			}
+		}
 	}
 
 	private boolean _equals(
@@ -269,6 +338,57 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		return null;
 	}
 
+	private long _getCompanyIdFromConfiguration(
+			ExtendedObjectClassDefinition.Scope scope,
+			Dictionary<String, Object> dictionary, String fileName)
+		throws Exception {
+
+		Object value = dictionary.get(scope.getPropertyKey());
+
+		if (value != null) {
+			try (Connection connection = _dataSource.getConnection();
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						_db.buildSQL(
+							"select companyId from Company where companyId = " +
+								"?"))) {
+
+				preparedStatement.setLong(1, (long)value);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					if (resultSet.next()) {
+						return resultSet.getLong(1);
+					}
+				}
+			}
+		}
+
+		value = dictionary.get(scope.getPortablePropertyKey());
+
+		if (value != null) {
+			try (Connection connection = _dataSource.getConnection();
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						_db.buildSQL(
+							"select companyId from Company where webId = ?"))) {
+
+				preparedStatement.setString(1, (String)value);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					if (resultSet.next()) {
+						return resultSet.getLong(1);
+					}
+				}
+			}
+		}
+
+		throw new Exception(
+			StringBundler.concat(
+				"Company for the scoped indicated in configuration file ",
+				fileName,
+				" has not been found. Configuration has not been applied."));
+	}
+
 	private Configuration _getConfiguration(
 			String fileName, String pid, String name)
 		throws Exception {
@@ -285,6 +405,28 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		}
 
 		return _configurationAdmin.getConfiguration(pid, StringPool.QUESTION);
+	}
+
+	private ExtendedObjectClassDefinition.Scope _getConfigurationScope(
+		Dictionary<String, Object> dictionary) {
+
+		for (ExtendedObjectClassDefinition.Scope scope :
+				ExtendedObjectClassDefinition.Scope.values()) {
+
+			String key = scope.getPortablePropertyKey();
+
+			if ((key != null) && (dictionary.get(key) != null)) {
+				return scope;
+			}
+
+			key = scope.getPropertyKey();
+
+			if ((key != null) && (dictionary.get(key) != null)) {
+				return scope;
+			}
+		}
+
+		return ExtendedObjectClassDefinition.Scope.SYSTEM;
 	}
 
 	private String[] _parsePid(String path) {
@@ -317,6 +459,7 @@ public class ConfigurationFileInstaller implements FileInstaller {
 	private final String _configsDirPath;
 	private final ConfigurationAdmin _configurationAdmin;
 	private final DataSource _dataSource;
+	private final DB _db = DBManagerUtil.getDB();
 	private final String _encoding;
 
 }

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -15,8 +15,6 @@ import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.file.install.internal.Util;
 import com.liferay.portal.file.install.properties.ConfigurationProperties;
 import com.liferay.portal.file.install.properties.ConfigurationPropertiesFactory;
-import com.liferay.portal.kernel.dao.db.DB;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -38,8 +36,6 @@ import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.sql.DataSource;
-
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -50,11 +46,9 @@ import org.osgi.service.cm.ConfigurationAdmin;
 public class ConfigurationFileInstaller implements FileInstaller {
 
 	public ConfigurationFileInstaller(
-		ConfigurationAdmin configurationAdmin, DataSource dataSource,
-		String encoding) {
+		ConfigurationAdmin configurationAdmin, String encoding) {
 
 		_configurationAdmin = configurationAdmin;
-		_dataSource = dataSource;
 		_encoding = encoding;
 
 		_configsDirPath = Util.getFilePath(
@@ -460,8 +454,6 @@ public class ConfigurationFileInstaller implements FileInstaller {
 
 	private final String _configsDirPath;
 	private final ConfigurationAdmin _configurationAdmin;
-	private final DataSource _dataSource;
-	private final DB _db = DBManagerUtil.getDB();
 	private final String _encoding;
 
 }

--- a/modules/apps/static/portal-file-install/portal-file-install-test/build.gradle
+++ b/modules/apps/static/portal-file-install/portal-file-install-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
+	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":apps:static:portal-file-install:portal-file-install-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
@@ -8,9 +8,16 @@ package com.liferay.portal.file.install.deploy.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -61,95 +68,32 @@ public class FileInstallDeployTest {
 		new LiferayIntegrationTestRule();
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(FileInstallDeployTest.class);
 
 		_bundleContext = bundle.getBundleContext();
+
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Test
-	public void testConfiguration() throws Exception {
-		Path path = Paths.get(
-			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR,
-			_CONFIGURATION_PID.concat(".config"));
-
-		try {
-			Configuration configuration =
-				ConfigurationTestUtil.updateConfiguration(
-					_CONFIGURATION_PID,
-					() -> {
-						String content1 = StringBundler.concat(
-							_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
-							_TEST_VALUE_1, StringPool.QUOTE);
-
-						Files.write(path, content1.getBytes());
-					});
-
-			Dictionary<String, Object> properties =
-				configuration.getProperties();
-
-			Assert.assertEquals(_TEST_VALUE_1, properties.get(_TEST_KEY));
-
-			configuration = ConfigurationTestUtil.updateConfiguration(
-				_CONFIGURATION_PID,
-				() -> {
-					String content = StringBundler.concat(
-						_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
-						_TEST_VALUE_2, StringPool.QUOTE);
-
-					Files.write(path, content.getBytes());
-
-					File file = path.toFile();
-
-					file.setLastModified(file.lastModified() + 1000);
-				});
-
-			properties = configuration.getProperties();
-
-			Assert.assertEquals(_TEST_VALUE_2, properties.get(_TEST_KEY));
-
-			configuration = ConfigurationTestUtil.updateConfiguration(
-				_CONFIGURATION_PID, () -> Files.delete(path));
-
-			Assert.assertNull(configuration);
-		}
-		finally {
-			Files.deleteIfExists(path);
-		}
+	public void testCompanyScopedConfiguration() throws Exception {
+		_testScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			String.valueOf(_company.getCompanyId()));
 	}
 
 	@Test
-	public void testConfigurationSystem() throws Exception {
-		Path path = Paths.get(
-			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR,
-			_CONFIGURATION_PID.concat(".config"));
-
-		String systemTestPropertyKey = StringBundler.concat(
-			_CONFIGURATION_PID, StringPool.PERIOD, _TEST_KEY);
-
-		System.setProperty(systemTestPropertyKey, _TEST_VALUE_1);
-
-		try {
-			Configuration configuration =
-				ConfigurationTestUtil.updateConfiguration(
-					_CONFIGURATION_PID,
-					() -> {
-						String content = StringBundler.concat(
-							_TEST_KEY, "=\"${", systemTestPropertyKey, "}\"");
-
-						Files.write(path, content.getBytes());
-					});
-
-			Dictionary<String, Object> properties =
-				configuration.getProperties();
-
-			Assert.assertEquals(_TEST_VALUE_1, properties.get(_TEST_KEY));
-		}
-		finally {
-			System.clearProperty(systemTestPropertyKey);
-
-			Files.deleteIfExists(path);
-		}
+	public void testCompanyScopedPortableKeyConfiguration() throws Exception {
+		_testScopedPortableKeyConfiguration(
+			ExtendedObjectClassDefinition.Scope.COMPANY.
+				getPortablePropertyKey(),
+			_company.getWebId(),
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			String.valueOf(_company.getCompanyId()));
 	}
 
 	@Test
@@ -345,6 +289,160 @@ public class FileInstallDeployTest {
 		}
 	}
 
+	@Test
+	public void testGroupScopedConfiguration() throws Exception {
+		_testScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+			String.valueOf(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGroupScopedPortableKeyConfiguration() throws Exception {
+		_testScopedPortableKeyConfiguration(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPortablePropertyKey(),
+			_company.getWebId() + "--" + _group.getGroupKey(),
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+			String.valueOf(_group.getGroupId()));
+	}
+
+	@Test
+	public void testPortletInstanceScopedConfiguration() throws Exception {
+		_testScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey(),
+			RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testSystemConfiguration() throws Exception {
+		Path path = Paths.get(
+			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR,
+			_CONFIGURATION_PID.concat(".config"));
+
+		String systemTestPropertyKey = StringBundler.concat(
+			_CONFIGURATION_PID, StringPool.PERIOD, _TEST_KEY);
+
+		System.setProperty(systemTestPropertyKey, _TEST_VALUE_1);
+
+		try {
+			Configuration configuration =
+				ConfigurationTestUtil.updateConfiguration(
+					_CONFIGURATION_PID,
+					() -> {
+						String content = StringBundler.concat(
+							_TEST_KEY, "=\"${", systemTestPropertyKey, "}\"");
+
+						Files.write(path, content.getBytes());
+					});
+
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			Assert.assertEquals(_TEST_VALUE_1, properties.get(_TEST_KEY));
+		}
+		finally {
+			System.clearProperty(systemTestPropertyKey);
+
+			Files.deleteIfExists(path);
+		}
+	}
+
+	@Test
+	public void testSystemScopedConfiguration() throws Exception {
+		_testScopedConfiguration(
+			ExtendedObjectClassDefinition.Scope.SYSTEM.getPropertyKey(),
+			RandomTestUtil.randomString());
+	}
+
+	private void _testScopedConfiguration(
+			String dictionaryKey, String dictionaryValue)
+		throws Exception {
+
+		_testScopedPortableKeyConfiguration(
+			dictionaryKey, dictionaryValue, dictionaryKey, dictionaryValue);
+	}
+
+	private void _testScopedPortableKeyConfiguration(
+			String dictionaryKey, String dictionaryValue, String validationKey,
+			String validationValue)
+		throws Exception {
+
+		Path path = Paths.get(
+			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR,
+			_CONFIGURATION_FACTORY_PID.concat(".config"));
+
+		try {
+			Configuration configuration =
+				ConfigurationTestUtil.updateFactoryConfiguration(
+					_CONFIGURATION_FACTORY_PID,
+					() -> {
+						String content = StringBundler.concat(
+							_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
+							_TEST_VALUE_1, StringPool.QUOTE);
+
+						if (dictionaryKey != null) {
+							content = StringBundler.concat(
+								content, StringPool.RETURN_NEW_LINE,
+								dictionaryKey, StringPool.EQUAL,
+								StringPool.QUOTE, dictionaryValue,
+								StringPool.QUOTE);
+						}
+
+						Files.write(path, content.getBytes());
+					});
+
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			Assert.assertEquals(_TEST_VALUE_1, properties.get(_TEST_KEY));
+
+			if (validationKey != null) {
+				Assert.assertEquals(
+					validationValue,
+					String.valueOf(properties.get(validationKey)));
+			}
+
+			configuration = ConfigurationTestUtil.updateFactoryConfiguration(
+				_CONFIGURATION_FACTORY_PID,
+				() -> {
+					String content = StringBundler.concat(
+						_TEST_KEY, StringPool.EQUAL, StringPool.QUOTE,
+						_TEST_VALUE_2, StringPool.QUOTE);
+
+					if (dictionaryKey != null) {
+						content = StringBundler.concat(
+							content, StringPool.RETURN_NEW_LINE, dictionaryKey,
+							StringPool.EQUAL, StringPool.QUOTE, dictionaryValue,
+							StringPool.QUOTE);
+					}
+
+					Files.write(path, content.getBytes());
+
+					File file = path.toFile();
+
+					file.setLastModified(file.lastModified() + 1000);
+				});
+
+			properties = configuration.getProperties();
+
+			Assert.assertEquals(_TEST_VALUE_2, properties.get(_TEST_KEY));
+
+			if (validationKey != null) {
+				Assert.assertEquals(
+					validationValue,
+					String.valueOf(properties.get(validationKey)));
+			}
+
+			configuration = ConfigurationTestUtil.updateFactoryConfiguration(
+				_CONFIGURATION_FACTORY_PID, () -> Files.delete(path));
+
+			Assert.assertNull(configuration);
+		}
+		finally {
+			Files.deleteIfExists(path);
+		}
+	}
+
 	private void _uninstall(String symbolicName, Path path) throws Exception {
 		if (!Files.exists(path)) {
 			return;
@@ -383,6 +481,9 @@ public class FileInstallDeployTest {
 		}
 	}
 
+	private static final String _CONFIGURATION_FACTORY_PID =
+		FileInstallDeployTest.class.getName() + "Configuration~foo";
+
 	private static final String _CONFIGURATION_PID =
 		FileInstallDeployTest.class.getName() + "Configuration";
 
@@ -408,6 +509,12 @@ public class FileInstallDeployTest {
 	}
 
 	private BundleContext _bundleContext;
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private Group _group;
 
 	private class JarBuilder {
 

--- a/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.wiki.layout.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER, "LayoutPrototype",

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -95,6 +95,8 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import javax.sql.DataSource;
+
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
@@ -1017,6 +1019,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		Constructor<?> constructor =
 			configurationFileInstallerClass.getDeclaredConstructor(
 				classLoader.loadClass("org.osgi.service.cm.ConfigurationAdmin"),
+				classLoader.loadClass(DataSource.class.getName()),
 				String.class);
 
 		constructor.setAccessible(true);
@@ -1032,6 +1035,11 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 			bundleContext.getService(
 				bundleContext.getServiceReference(
 					"org.osgi.service.cm.ConfigurationAdmin")),
+			bundleContext.getService(
+				bundleContext.getServiceReferences(
+					DataSource.class, "(bean.id=liferayDataSource)"
+				).iterator(
+				).next()),
 			ModuleFrameworkPropsValues.
 				MODULE_FRAMEWORK_FILE_INSTALL_CONFIG_ENCODING);
 

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -95,8 +95,6 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import javax.sql.DataSource;
-
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
@@ -1019,7 +1017,6 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		Constructor<?> constructor =
 			configurationFileInstallerClass.getDeclaredConstructor(
 				classLoader.loadClass("org.osgi.service.cm.ConfigurationAdmin"),
-				classLoader.loadClass(DataSource.class.getName()),
 				String.class);
 
 		constructor.setAccessible(true);
@@ -1035,11 +1032,6 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 			bundleContext.getService(
 				bundleContext.getServiceReference(
 					"org.osgi.service.cm.ConfigurationAdmin")),
-			bundleContext.getService(
-				bundleContext.getServiceReferences(
-					DataSource.class, "(bean.id=liferayDataSource)"
-				).iterator(
-				).next()),
 			ModuleFrameworkPropsValues.
 				MODULE_FRAMEWORK_FILE_INSTALL_CONFIG_ENCODING);
 

--- a/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultCompanyNameSwapper.java
+++ b/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultCompanyNameSwapper.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.properties.swapper.internal;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -13,7 +14,6 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Objects;
@@ -40,7 +40,7 @@ public class DefaultCompanyNameSwapper {
 
 		try {
 			Company defaultCompany = _companyLocalService.getCompany(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			if (!_hasCustomCompanyName(
 					defaultCompany, originalCompanyDefaultName)) {

--- a/modules/util/portal-tools-db-partition-virtual-instance-migrator/src/main/java/com/liferay/portal/tools/db/partition/virtual/instance/migrator/util/DatabaseUtil.java
+++ b/modules/util/portal-tools-db-partition-virtual-instance-migrator/src/main/java/com/liferay/portal/tools/db/partition/virtual/instance/migrator/util/DatabaseUtil.java
@@ -52,7 +52,7 @@ public class DatabaseUtil {
 		DBInspector dbInspector = new DBInspector(connection);
 
 		for (String tableName : dbInspector.getTableNames(null)) {
-			if (!dbInspector.isControlTable(companyIds, tableName) &&
+			if (!dbInspector.isControlTable(tableName) &&
 				!dbInspector.isObjectTable(companyIds, tableName)) {
 
 				partitionedTableNames.add(tableName);

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -202,7 +202,7 @@
 			<property name="enabled" value="false" />
 			<message key="company.local.service.use.for.loop" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
 			<message key="company.local.service.use.sql" value="Use ''CompanyLocalService.forEachCompany'' instead of SQL" />
-			<message key="portal.instances.use" value="Use ''PortalInstances.getCompanyIdsBySQL'' instead to fetch company IDs" />
+			<message key="portal.instances.use" value="Use ''PortalInstancePool.getCompanyIds'' instead to fetch company IDs" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ConcatCheck">
 			<property name="category" value="Performance" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -272,7 +272,7 @@
 			<property name="enabled" value="false" />
 			<message key="company.local.service.use.for.loop" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
 			<message key="company.local.service.use.sql" value="Use ''CompanyLocalService.forEachCompany'' instead of SQL" />
-			<message key="portal.instances.use" value="Use ''PortalInstances.getCompanyIdsBySQL'' instead to fetch company IDs" />
+			<message key="portal.instances.use" value="Use ''PortalInstancePool.getCompanyIds'' instead to fetch company IDs" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ComponentAnnotationCheck">
 			<property name="category" value="Bug Prevention" />

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -776,8 +776,9 @@ public class DBPartitionUtil {
 		try {
 			DBInspector dbInspector = new DBInspector(connection);
 
-			if (dbInspector.isControlTable(tableName) &&
-				!(CompanyThreadLocal.getCompanyId() == _defaultCompanyId)) {
+			if ((dbInspector.isControlTable(tableName) &&
+				 !(CompanyThreadLocal.getCompanyId() == _defaultCompanyId)) ||
+				dbInspector.hasView(tableName)) {
 
 				return true;
 			}

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -31,7 +32,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.spring.hibernate.DialectDetector;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
@@ -498,7 +498,7 @@ public class DBPartitionUtil {
 
 	private static List<Long> _getCompanyIds() throws SQLException {
 		if (_companyIds.isEmpty()) {
-			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+			for (long companyId : PortalInstancePool.getCompanyIds()) {
 				_companyIds.add(companyId);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -209,7 +209,8 @@ public class DBPartitionUtil {
 		return true;
 	}
 
-	public static void replaceByTable(Connection connection, String viewName)
+	public static void replaceByTable(
+			Connection connection, boolean copyData, String viewName)
 		throws Exception {
 
 		long companyId = getCurrentCompanyId();
@@ -223,9 +224,11 @@ public class DBPartitionUtil {
 
 			statement.execute(_getCreateTableSQL(companyId, viewName));
 
-			_copyData(
-				viewName, _defaultSchemaName, _getSchemaName(companyId),
-				statement, StringPool.BLANK);
+			if (copyData) {
+				_copyData(
+					viewName, _defaultSchemaName, _getSchemaName(companyId),
+					statement, StringPool.BLANK);
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -721,9 +721,7 @@ public class DBPartitionUtil {
 				while (resultSet.next()) {
 					String tableName = resultSet.getString("TABLE_NAME");
 
-					if (dbInspector.isControlTable(
-							_getCompanyIds(), tableName)) {
-
+					if (dbInspector.isControlTable(tableName)) {
 						if (dbInspector.hasColumn(tableName, "companyId")) {
 							_copyData(
 								tableName, _getSchemaName(companyId),

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -90,9 +90,7 @@ public class DBPartitionUtil {
 						continue;
 					}
 
-					if (dbInspector.isControlTable(
-							_getCompanyIds(), tableName)) {
-
+					if (dbInspector.isControlTable(tableName)) {
 						statement.executeUpdate(
 							_getCreateViewSQL(companyId, tableName));
 					}
@@ -332,8 +330,7 @@ public class DBPartitionUtil {
 				while (resultSet.next()) {
 					String tableName = resultSet.getString("TABLE_NAME");
 
-					if (dbInspector.isControlTable(
-							_getCompanyIds(), tableName) &&
+					if (dbInspector.isControlTable(tableName) &&
 						dbInspector.hasColumn(tableName, "companyId")) {
 
 						statement.executeUpdate(
@@ -376,9 +373,7 @@ public class DBPartitionUtil {
 				while (resultSet.next()) {
 					String tableName = resultSet.getString("TABLE_NAME");
 
-					if (dbInspector.isControlTable(
-							_getCompanyIds(), tableName)) {
-
+					if (dbInspector.isControlTable(tableName)) {
 						controlTableNames.add(tableName);
 
 						_extractTable(
@@ -781,7 +776,7 @@ public class DBPartitionUtil {
 		try {
 			DBInspector dbInspector = new DBInspector(connection);
 
-			if (dbInspector.isControlTable(_getCompanyIds(), tableName) &&
+			if (dbInspector.isControlTable(tableName) &&
 				!(CompanyThreadLocal.getCompanyId() == _defaultCompanyId)) {
 
 				return true;
@@ -858,9 +853,7 @@ public class DBPartitionUtil {
 					DBInspector dbInspector = new DBInspector(connection);
 					String tableName = query[2];
 
-					if (!dbInspector.isControlTable(
-							_getCompanyIds(), tableName)) {
-
+					if (!dbInspector.isControlTable(tableName)) {
 						return returnValue;
 					}
 

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -411,7 +411,7 @@ public class MainServlet extends HttpServlet {
 
 			try {
 				SetupWizardSampleDataUtil.addSampleData(
-					PortalInstances.getDefaultCompanyId());
+					PortalInstancePool.getDefaultCompanyId());
 			}
 			catch (Exception exception) {
 				_log.error(exception);

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -108,6 +109,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletContext;
@@ -788,6 +790,8 @@ public class MainServlet extends HttpServlet {
 			throw new RuntimeException("Company default web ID is null");
 		}
 
+		List<Company> companies = new CopyOnWriteArrayList<>();
+
 		CompanyLocalServiceUtil.forEachCompany(
 			company -> {
 				if (StartupHelperUtil.isDBNew() &&
@@ -795,12 +799,16 @@ public class MainServlet extends HttpServlet {
 						PropsValues.COMPANY_DEFAULT_WEB_ID,
 						company.getWebId())) {
 
-					PortalInstances.initCompany(company, true);
+					PortalInstances.initCompany(company, true, true);
 				}
 				else {
-					PortalInstances.initCompany(company, false);
+					PortalInstances.initCompany(company, false, true);
 				}
+
+				companies.add(company);
 			});
+
+		PortalInstancePool.add(companies);
 	}
 
 	private void _initLayoutTemplates(PluginPackage pluginPackage) {

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -807,7 +807,7 @@ public class MainServlet extends HttpServlet {
 				companies.add(company);
 			});
 
-		PortalInstancePool.add(companies);
+		PortalInstancePool.set(companies);
 	}
 
 	private void _initLayoutTemplates(PluginPackage pluginPackage) {

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -109,7 +109,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletContext;
@@ -790,7 +789,7 @@ public class MainServlet extends HttpServlet {
 			throw new RuntimeException("Company default web ID is null");
 		}
 
-		List<Company> companies = new CopyOnWriteArrayList<>();
+		List<Company> companies = new ArrayList<>();
 
 		CompanyLocalServiceUtil.forEachCompany(
 			company -> {

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -798,10 +798,10 @@ public class MainServlet extends HttpServlet {
 						PropsValues.COMPANY_DEFAULT_WEB_ID,
 						company.getWebId())) {
 
-					PortalInstances.initCompany(company, true, true);
+					PortalInstances.initCompany(company, true);
 				}
 				else {
-					PortalInstances.initCompany(company, false, true);
+					PortalInstances.initCompany(company, false);
 				}
 
 				companies.add(company);

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -383,7 +383,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					registerCompany(dbPartitionCompany);
 
-					PortalInstances.initCompany(dbPartitionCompany, true);
+					PortalInstances.initCompany(
+						dbPartitionCompany, true, false);
 
 					return null;
 				});

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -384,8 +384,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					registerCompany(dbPartitionCompany);
 
-					PortalInstances.initCompany(
-						dbPartitionCompany, true, false);
+					PortalInstances.initCompany(dbPartitionCompany, true);
 
 					return null;
 				});

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.instance.lifecycle.PortalInstanceLifecycleManager;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -328,7 +329,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				"Database partition must be enabled");
 		}
 
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new IllegalArgumentException(
 				"Company ID " + companyId + " is the default company ID");
 		}
@@ -446,7 +447,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 	@Override
 	public Company deleteCompany(long companyId) throws PortalException {
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new RequiredCompanyException(
 				"Select another default company before deleting company " +
 					companyId);
@@ -491,7 +492,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				"Database partition must be enabled");
 		}
 
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new RequiredCompanyException(
 				"Select another default company before extracting company " +
 					companyId);
@@ -738,7 +739,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	 */
 	@Override
 	public long getCompanyIdByUserId(long userId) throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIds();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		long companyId = 0;
 
@@ -880,7 +881,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		virtualHostname = StringUtil.toLowerCase(
 			StringUtil.trim(virtualHostname));
 
-		if (!active && (companyId == PortalInstances.getDefaultCompanyId())) {
+		if (!active &&
+			(companyId == PortalInstancePool.getDefaultCompanyId())) {
+
 			throw new RequiredCompanyException(
 				"Select another default company before deactivating company " +
 					companyId);
@@ -2211,7 +2214,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
 
 		while ((nextLong == 0) ||
-			   ArrayUtil.contains(PortalInstances.getCompanyIds(), nextLong)) {
+			   ArrayUtil.contains(
+				   PortalInstancePool.getCompanyIds(), nextLong)) {
 
 			nextLong = threadLocalRandom.nextLong(
 				(long)Math.pow(10, 15), Long.MAX_VALUE);

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceMode;
 import com.liferay.portal.kernel.model.Country;
@@ -17,7 +18,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.base.CountryServiceBaseImpl;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.List;
 
@@ -88,7 +88,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country fetchCountryByA2(String a2) {
-		return fetchCountryByA2(PortalInstances.getDefaultCompanyId(), a2);
+		return fetchCountryByA2(PortalInstancePool.getDefaultCompanyId(), a2);
 	}
 
 	@Override
@@ -102,7 +102,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country fetchCountryByA3(String a3) {
-		return fetchCountryByA3(PortalInstances.getDefaultCompanyId(), a3);
+		return fetchCountryByA3(PortalInstancePool.getDefaultCompanyId(), a3);
 	}
 
 	@Override
@@ -150,7 +150,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public List<Country> getCountries() {
-		return getCompanyCountries(PortalInstances.getDefaultCompanyId());
+		return getCompanyCountries(PortalInstancePool.getDefaultCompanyId());
 	}
 
 	/**
@@ -161,7 +161,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Override
 	public List<Country> getCountries(boolean active) {
 		return getCompanyCountries(
-			PortalInstances.getDefaultCompanyId(), active);
+			PortalInstancePool.getDefaultCompanyId(), active);
 	}
 
 	@Override
@@ -182,7 +182,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country getCountryByA2(String a2) throws PortalException {
-		return getCountryByA2(PortalInstances.getDefaultCompanyId(), a2);
+		return getCountryByA2(PortalInstancePool.getDefaultCompanyId(), a2);
 	}
 
 	@Override
@@ -198,7 +198,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country getCountryByA3(String a3) throws PortalException {
-		return getCountryByA3(PortalInstances.getDefaultCompanyId(), a3);
+		return getCountryByA3(PortalInstancePool.getDefaultCompanyId(), a3);
 	}
 
 	@Override
@@ -214,7 +214,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country getCountryByName(String name) throws PortalException {
-		return getCountryByName(PortalInstances.getDefaultCompanyId(), name);
+		return getCountryByName(PortalInstancePool.getDefaultCompanyId(), name);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
+++ b/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
@@ -11,6 +11,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -72,7 +73,7 @@ public class SetupWizardUtil {
 	public static String getDefaultTimeZoneId() {
 		try {
 			Company company = CompanyLocalServiceUtil.getCompanyById(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			User guestUser = company.getGuestUser();
 
@@ -143,7 +144,7 @@ public class SetupWizardUtil {
 			httpServletRequest, "companyTimeZoneId", getDefaultTimeZoneId());
 
 		CompanyLocalServiceUtil.updateDisplay(
-			PortalInstances.getDefaultCompanyId(), languageId, timeZoneId);
+			PortalInstancePool.getDefaultCompanyId(), languageId, timeZoneId);
 
 		_updateLanguage(
 			httpServletRequest, httpServletResponse, languageId, locale);
@@ -406,7 +407,7 @@ public class SetupWizardUtil {
 		throws Exception {
 
 		Company company = CompanyLocalServiceUtil.getCompanyById(
-			PortalInstances.getDefaultCompanyId());
+			PortalInstancePool.getDefaultCompanyId());
 
 		String languageId = ParamUtil.getString(
 			httpServletRequest, "companyLocale", getDefaultLanguageId());

--- a/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTable.java
@@ -20,7 +20,7 @@ public class UpgradePartitionedControlTable extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		DBPartitionUtil.replaceByTable(connection, _tableName);
+		DBPartitionUtil.replaceByTable(connection, true, _tableName);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeDocumentLibrary.java
@@ -10,6 +10,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.TreeModel;
@@ -27,7 +28,6 @@ import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.Serializable;
 
@@ -302,7 +302,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 		_runSQL("create index IX_LPP_41834_EYIW on DLFolder (userId);");
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			for (long companyId : companyIds) {
 				try (PreparedStatement folderPreparedStatement =

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeCompanyId.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.upgrade.v7_0_0;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseCompanyIdUpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.IOException;
 
@@ -152,7 +152,7 @@ public class UpgradeCompanyId extends BaseCompanyIdUpgradeProcess {
 		public void update(Connection connection)
 			throws IOException, SQLException {
 
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			if (companyIds.length == 1) {
 				runSQL(connection, getUpdateSQL(String.valueOf(companyIds[0])));

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -27,7 +28,6 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortalPreferencesImpl;
 import com.liferay.portlet.PortalPreferencesWrapper;
@@ -59,7 +59,7 @@ public class UpgradeGroup extends UpgradeProcess {
 	}
 
 	protected void updateGlobalGroupName() throws Exception {
-		for (Long companyId : PortalInstances.getCompanyIdsBySQL()) {
+		for (Long companyId : PortalInstancePool.getCompanyIds()) {
 			LocalizedValuesMap localizedValuesMap = new LocalizedValuesMap();
 
 			for (String languageId : PropsValues.LOCALES_ENABLED) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradePortalPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradePortalPreferences.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.v7_0_5;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -17,7 +18,6 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,7 +34,7 @@ public class UpgradePortalPreferences extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			upgradePortalPreferences(PortletKeys.PREFS_OWNER_ID_DEFAULT);
 
-			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+			for (long companyId : PortalInstancePool.getCompanyIds()) {
 				upgradePortalPreferences(companyId);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeCompanyId.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseCompanyIdUpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.IOException;
 
@@ -56,7 +56,7 @@ public class UpgradeCompanyId extends BaseCompanyIdUpgradeProcess {
 		public void update(Connection connection)
 			throws IOException, SQLException {
 
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			if (companyIds.length == 1) {
 				runSQL(connection, getUpdateSQL(String.valueOf(companyIds[0])));

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeCompanyId.java
@@ -186,7 +186,7 @@ public class UpgradeListTypeCompanyId extends UpgradeProcess {
 			runSQL("update ListType set companyId = " + defaultCompanyId);
 		}
 		else {
-			DBPartitionUtil.replaceByTable(connection, "ListType");
+			DBPartitionUtil.replaceByTable(connection, true, "ListType");
 
 			runSQL(
 				"update ListType set companyId = " +

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeCompanyId.java
@@ -7,6 +7,7 @@ package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -14,7 +15,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,7 +34,7 @@ public class UpgradeListTypeCompanyId extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long defaultCompanyId = PortalInstances.getDefaultCompanyIdBySQL();
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 
 		_resetCounter(defaultCompanyId);
 
@@ -167,7 +167,7 @@ public class UpgradeListTypeCompanyId extends UpgradeProcess {
 
 		runSQL("update ListType set companyId = " + defaultCompanyId);
 
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		List<ListTypeEntry> listTypeEntries = _getListTypes();
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -27,7 +27,7 @@ public class UpgradeListTypeType extends UpgradeProcess {
 			return;
 		}
 
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		for (long companyId : companyIds) {
 			_updateListType(companyId, "intranet");

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RSSFeedException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.image.ImageBag;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.language.constants.LanguageConstants;
 import com.liferay.portal.kernel.log.Log;
@@ -1752,7 +1753,7 @@ public class PortalImpl implements Portal {
 
 			if (company == null) {
 				company = CompanyLocalServiceUtil.getCompanyById(
-					PortalInstances.getDefaultCompanyId());
+					PortalInstancePool.getDefaultCompanyId());
 			}
 
 			httpServletRequest.setAttribute(WebKeys.COMPANY, company);
@@ -1780,7 +1781,7 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public long[] getCompanyIds() {
-		return PortalInstances.getCompanyIds();
+		return PortalInstancePool.getCompanyIds();
 	}
 
 	@Override
@@ -2184,7 +2185,7 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public long getDefaultCompanyId() {
-		return PortalInstances.getDefaultCompanyId();
+		return PortalInstancePool.getDefaultCompanyId();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -125,7 +125,7 @@ public class PortalInstances {
 		}
 
 		if (companyId <= 0) {
-			companyId = getDefaultCompanyId();
+			companyId = PortalInstancePool.getDefaultCompanyId();
 
 			if (_log.isDebugEnabled()) {
 				_log.debug("Default company ID " + companyId);

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -10,7 +10,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -38,12 +36,8 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -177,70 +171,42 @@ public class PortalInstances {
 		return companyId;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getCompanyIds()}
+	 */
+	@Deprecated
 	public static long[] getCompanyIds() {
 		return PortalInstancePool.getCompanyIds();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getCompanyIds()}
+	 */
+	@Deprecated
 	public static long[] getCompanyIdsBySQL() throws SQLException {
-		List<Long> companyIds = new ArrayList<>();
-
-		long defaultCompanyId = getDefaultCompanyIdBySQL();
-
-		if (defaultCompanyId != 0) {
-			companyIds.add(defaultCompanyId);
-		}
-
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				_GET_COMPANY_IDS);
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
-
-				if (companyId != defaultCompanyId) {
-					companyIds.add(companyId);
-				}
-			}
-		}
-
-		return ArrayUtil.toArray(companyIds.toArray(new Long[0]));
+		return PortalInstancePool.getCompanyIds();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getDefaultCompanyId()}
+	 */
+	@Deprecated
 	public static long getDefaultCompanyId() {
-		long[] companyIds = PortalInstancePool.getCompanyIds();
-
-		if (companyIds.length == 0) {
-			try {
-				return getDefaultCompanyIdBySQL();
-			}
-			catch (SQLException sqlException) {
-				_log.error(
-					"Unable to get the default company ID by SQL",
-					sqlException);
-
-				throw new RuntimeException(sqlException);
-			}
-		}
-
 		return PortalInstancePool.getDefaultCompanyId();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getDefaultCompanyId()}
+	 */
+	@Deprecated
 	public static long getDefaultCompanyIdBySQL() throws SQLException {
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select companyId from Company where webId = '" +
-					PropsValues.COMPANY_DEFAULT_WEB_ID + "'");
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (resultSet.next()) {
-				return resultSet.getLong(1);
-			}
-		}
-
-		return 0;
+		return PortalInstancePool.getDefaultCompanyId();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getWebIds()} ()}
+	 */
+	@Deprecated
 	public static String[] getWebIds() {
 		return PortalInstancePool.getWebIds();
 	}
@@ -540,9 +506,6 @@ public class PortalInstances {
 
 	private PortalInstances() {
 	}
-
-	private static final String _GET_COMPANY_IDS =
-		"select companyId from Company";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstances.class);

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -212,10 +212,11 @@ public class PortalInstances {
 	}
 
 	public static long initCompany(Company company) {
-		return initCompany(company, false);
+		return initCompany(company, false, false);
 	}
 
-	public static long initCompany(Company company, boolean skipCheck) {
+	public static long initCompany(
+		Company company, boolean skipCheck, boolean skipPool) {
 
 		// Begin initializing company
 
@@ -317,7 +318,9 @@ public class PortalInstances {
 						company.getCompanyId()));
 			}
 
-			PortalInstancePool.add(company);
+			if (!skipPool) {
+				PortalInstancePool.add(company);
+			}
 		}
 		finally {
 			CompanyThreadLocal.setCompanyId(currentThreadCompanyId);

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -212,11 +212,10 @@ public class PortalInstances {
 	}
 
 	public static long initCompany(Company company) {
-		return initCompany(company, false, false);
+		return initCompany(company, false);
 	}
 
-	public static long initCompany(
-		Company company, boolean skipCheck, boolean skipPool) {
+	public static long initCompany(Company company, boolean skipCheck) {
 
 		// Begin initializing company
 
@@ -318,9 +317,7 @@ public class PortalInstances {
 						company.getCompanyId()));
 			}
 
-			if (!skipPool) {
-				PortalInstancePool.add(company);
-			}
+			PortalInstancePool.add(company);
 		}
 		finally {
 			CompanyThreadLocal.setCompanyId(currentThreadCompanyId);

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 61.1.0
+version 62.0.0

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -33,7 +34,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.impl.GroupLocalServiceImpl;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -342,7 +342,7 @@ public class VerifyGroup extends VerifyProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			CompanyLocalServiceUtil.forEachCompanyId(
 				companyId -> GroupLocalServiceUtil.rebuildTree(companyId),
-				PortalInstances.getCompanyIdsBySQL());
+				PortalInstancePool.getCompanyIds());
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyPermission.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyPermission.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -33,7 +34,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.HashMap;
 import java.util.List;
@@ -173,7 +173,7 @@ public class VerifyPermission extends VerifyProcess {
 			CompanyLocalServiceUtil.forEachCompanyId(
 				companyId -> fixUserDefaultRolePermissions(
 					userClassNameId, userGroupClassNameId, companyId),
-				PortalInstances.getCompanyIdsBySQL());
+				PortalInstancePool.getCompanyIds());
 		}
 		finally {
 			EntityCacheUtil.clearCache();

--- a/portal-impl/src/com/liferay/portal/verify/VerifyRole.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyRole.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.verify;
 
 import com.liferay.portal.kernel.exception.NoSuchRoleException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -19,7 +20,6 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Brian Wing Shun Chan
@@ -56,7 +56,7 @@ public class VerifyRole extends VerifyProcess {
 	protected void doVerify() throws Exception {
 		CompanyLocalServiceUtil.forEachCompanyId(
 			companyId -> verifyRoles(companyId),
-			PortalInstances.getCompanyIdsBySQL());
+			PortalInstancePool.getCompanyIds());
 	}
 
 	protected void verifyRoles(long companyId) throws Exception {

--- a/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
+++ b/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portlet.admin.util;
 
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -14,7 +15,6 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 /**
@@ -65,7 +65,7 @@ public class OmniadminUtil {
 				for (int i = 0; i < PropsValues.OMNIADMIN_USERS.length; i++) {
 					if (PropsValues.OMNIADMIN_USERS[i] == user.getUserId()) {
 						if (user.getCompanyId() !=
-								PortalInstances.getDefaultCompanyId()) {
+								PortalInstancePool.getDefaultCompanyId()) {
 
 							return false;
 						}
@@ -79,14 +79,14 @@ public class OmniadminUtil {
 
 			if (user.isGuestUser() ||
 				(user.getCompanyId() !=
-					PortalInstances.getDefaultCompanyId())) {
+					PortalInstancePool.getDefaultCompanyId())) {
 
 				return false;
 			}
 
 			try (SafeCloseable safeCloseable =
 					CompanyThreadLocal.setWithSafeCloseable(
-						PortalInstances.getDefaultCompanyId())) {
+						PortalInstancePool.getDefaultCompanyId())) {
 
 				return RoleLocalServiceUtil.hasUserRole(
 					user.getUserId(), user.getCompanyId(),

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 15.0.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 15.0.0
+version 14.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -370,6 +370,12 @@ public abstract class BaseDBProcess implements DBProcess {
 		return dbInspector.hasTable(tableName);
 	}
 
+	protected boolean hasView(String viewName) throws Exception {
+		DBInspector dbInspector = new DBInspector(connection);
+
+		return dbInspector.hasView(viewName);
+	}
+
 	protected void process(UnsafeConsumer<Long, Exception> unsafeConsumer)
 		throws Exception {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -246,7 +246,7 @@ public class DBInspector {
 	public boolean hasTable(String tableName, boolean caseSensitive)
 		throws Exception {
 
-		return _hasTable(tableName, "TABLE", caseSensitive);
+		return _hasElement(tableName, "TABLE", caseSensitive);
 	}
 
 	public boolean hasView(String viewName) throws Exception {
@@ -256,7 +256,7 @@ public class DBInspector {
 	public boolean hasView(String viewName, boolean caseSensitive)
 		throws Exception {
 
-		return _hasTable(viewName, "VIEW", caseSensitive);
+		return _hasElement(viewName, "VIEW", caseSensitive);
 	}
 
 	public boolean isControlTable(String tableName) {
@@ -401,7 +401,7 @@ public class DBInspector {
 			normalizeName(tableName, databaseMetaData), columnName);
 	}
 
-	private boolean _hasTable(
+	private boolean _hasElement(
 			String elementName, String elementType, boolean caseSensitive)
 		throws Exception {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -246,21 +246,17 @@ public class DBInspector {
 	public boolean hasTable(String tableName, boolean caseSensitive)
 		throws Exception {
 
-		DatabaseMetaData databaseMetaData = _connection.getMetaData();
+		return _hasTable(tableName, "TABLE", caseSensitive);
+	}
 
-		if (!caseSensitive) {
-			tableName = normalizeName(tableName, databaseMetaData);
-		}
+	public boolean hasView(String viewName) throws Exception {
+		return hasView(viewName, false);
+	}
 
-		try (ResultSet resultSet = databaseMetaData.getTables(
-				getCatalog(), getSchema(), tableName, new String[] {"TABLE"})) {
+	public boolean hasView(String viewName, boolean caseSensitive)
+		throws Exception {
 
-			while (resultSet.next()) {
-				return true;
-			}
-		}
-
-		return false;
+		return _hasTable(viewName, "VIEW", caseSensitive);
 	}
 
 	public boolean isControlTable(String tableName) {
@@ -403,6 +399,28 @@ public class DBInspector {
 		return databaseMetaData.getColumns(
 			getCatalog(), getSchema(),
 			normalizeName(tableName, databaseMetaData), columnName);
+	}
+
+	private boolean _hasTable(
+			String elementName, String elementType, boolean caseSensitive)
+		throws Exception {
+
+		DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+		if (!caseSensitive) {
+			elementName = normalizeName(elementName, databaseMetaData);
+		}
+
+		try (ResultSet resultSet = databaseMetaData.getTables(
+				getCatalog(), getSchema(), elementName,
+				new String[] {elementType})) {
+
+			if (resultSet.next()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isColumnNullable(String typeName) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -263,13 +263,13 @@ public class DBInspector {
 		return false;
 	}
 
-	public boolean isControlTable(List<Long> companyIds, String tableName)
-		throws Exception {
-
-		if (!isPartitionedControlTable(tableName) &&
-			!isObjectTable(companyIds, tableName) &&
-			(_controlTableNames.contains(StringUtil.toLowerCase(tableName)) ||
-			 !hasColumn(tableName, "companyId"))) {
+	public boolean isControlTable(String tableName) {
+		if (_controlTableNames.contains(StringUtil.toLowerCase(tableName)) ||
+			StringUtil.toLowerCase(
+				tableName
+			).startsWith(
+				"quartz"
+			)) {
 
 			return true;
 		}
@@ -426,7 +426,9 @@ public class DBInspector {
 	private static final Pattern _columnTypePattern = Pattern.compile(
 		"(^\\w+)", Pattern.CASE_INSENSITIVE);
 	private static final Set<String> _controlTableNames = new HashSet<>(
-		Arrays.asList("company", "virtualhost"));
+		Arrays.asList(
+			"company", "counter", "release_", "servicecomponent",
+			"virtualhost"));
 	private static final Set<String> _partitionedControlTableNames =
 		new HashSet<>(Arrays.asList("classname_", "resourceaction"));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 15.3.0
+version 16.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -39,10 +39,6 @@ public class PortalInstancePool {
 		}
 	}
 
-	public static void add(long companyId, String webId) {
-		_portalInstances.put(companyId, webId);
-	}
-
 	public static long getCompanyId(String webId) {
 		if (!_portalInstances.isEmpty()) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -39,6 +39,10 @@ public class PortalInstancePool {
 		}
 	}
 
+	public static void add(long companyId, String webId) {
+		_portalInstances.put(companyId, webId);
+	}
+
 	public static long getCompanyId(String webId) {
 		if (!_portalInstances.isEmpty()) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -5,11 +5,21 @@
 
 package com.liferay.portal.kernel.instance;
 
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,9 +34,117 @@ public class PortalInstancePool {
 	}
 
 	public static long getCompanyId(String webId) {
-		for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
-			if (Objects.equals(entry.getValue(), webId)) {
-				return entry.getKey();
+		if (!_portalInstances.isEmpty()) {
+			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
+				if (Objects.equals(entry.getValue(), webId)) {
+					return entry.getKey();
+				}
+			}
+
+			throw new IllegalArgumentException(
+				"Unable to get company ID with web ID" + webId);
+		}
+
+		try {
+			return _getCompanyIdBySQL(webId);
+		}
+		catch (SQLException sqlException) {
+			_log.error(
+				"Unable to get the company ID for webId " + webId + " by SQL",
+				sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
+	}
+
+	public static long[] getCompanyIds() {
+		if (!_portalInstances.isEmpty()) {
+			return ArrayUtil.toLongArray(_portalInstances.keySet());
+		}
+
+		try {
+			return _getCompanyIdsBySQL();
+		}
+		catch (SQLException sqlException) {
+			_log.error("Unable to get the company IDs by SQL", sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
+	}
+
+	public static long getDefaultCompanyId() {
+		if (!_portalInstances.isEmpty()) {
+			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
+				if (Objects.equals(
+						PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID),
+						entry.getValue())) {
+
+					return entry.getKey();
+				}
+			}
+
+			throw new IllegalStateException("Unable to get default company ID");
+		}
+
+		try {
+			return _getDefaultCompanyIdBySQL();
+		}
+		catch (SQLException sqlException) {
+			_log.error(
+				"Unable to get the default company ID by SQL", sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
+	}
+
+	public static String getWebId(long companyId) {
+		if (!_portalInstances.isEmpty()) {
+			return _portalInstances.get(companyId);
+		}
+
+		try {
+			return _getWebIdBySQL(companyId);
+		}
+		catch (SQLException sqlException) {
+			_log.error(
+				"Unable to get the web ID for company with companyID " +
+					companyId + " by SQL",
+				sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
+	}
+
+	public static String[] getWebIds() {
+		if (!_portalInstances.isEmpty()) {
+			return ArrayUtil.toStringArray(_portalInstances.values());
+		}
+
+		try {
+			return _getWebIdsBySQL();
+		}
+		catch (SQLException sqlException) {
+			_log.error("Unable to get the web IDs by SQL", sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
+	}
+
+	public static void remove(long companyId) {
+		_portalInstances.remove(companyId);
+	}
+
+	private static long _getCompanyIdBySQL(String webId) throws SQLException {
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company where webId = ?")) {
+
+			preparedStatement.setString(1, webId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getLong(1);
+				}
 			}
 		}
 
@@ -34,34 +152,88 @@ public class PortalInstancePool {
 			"Unable to get company ID with web ID" + webId);
 	}
 
-	public static long[] getCompanyIds() {
-		return ArrayUtil.toLongArray(_portalInstances.keySet());
-	}
+	private static long[] _getCompanyIdsBySQL() throws SQLException {
+		List<Long> companyIds = new ArrayList<>();
 
-	public static long getDefaultCompanyId() {
-		for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
-			if (Objects.equals(
-					PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID),
-					entry.getValue())) {
+		long defaultCompanyId = _getDefaultCompanyIdBySQL();
 
-				return entry.getKey();
+		if (defaultCompanyId != 0) {
+			companyIds.add(defaultCompanyId);
+		}
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+
+				if (companyId != defaultCompanyId) {
+					companyIds.add(companyId);
+				}
 			}
 		}
 
-		throw new IllegalStateException("Unable to get default company ID");
+		return ArrayUtil.toArray(companyIds.toArray(new Long[0]));
 	}
 
-	public static String getWebId(long companyId) {
-		return _portalInstances.get(companyId);
+	private static long _getDefaultCompanyIdBySQL() throws SQLException {
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company where webId = '" +
+					_COMPANY_DEFAULT_WEB_ID + "'");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				return resultSet.getLong(1);
+			}
+		}
+
+		return 0;
 	}
 
-	public static String[] getWebIds() {
-		return ArrayUtil.toStringArray(_portalInstances.values());
+	private static String _getWebIdBySQL(long companyId) throws SQLException {
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select webId from Company where companyId = ?")) {
+
+			preparedStatement.setLong(1, companyId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getString(1);
+				}
+			}
+		}
+
+		throw new IllegalArgumentException(
+			"Unable to get web ID with company ID" + companyId);
 	}
 
-	public static void remove(long companyId) {
-		_portalInstances.remove(companyId);
+	private static String[] _getWebIdsBySQL() throws SQLException {
+		List<String> webIds = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select webId from Company");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				String webId = resultSet.getString("webId");
+
+				webIds.add(webId);
+			}
+		}
+
+		return webIds.toArray(new String[0]);
 	}
+
+	private static final String _COMPANY_DEFAULT_WEB_ID = PropsUtil.get(
+		PropsKeys.COMPANY_DEFAULT_WEB_ID);
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalInstancePool.class);
 
 	private static final Map<Long, String> _portalInstances =
 		new ConcurrentHashMap<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -33,6 +33,12 @@ public class PortalInstancePool {
 		_portalInstances.put(company.getCompanyId(), company.getWebId());
 	}
 
+	public static void add(List<Company> companies) {
+		for (Company company : companies) {
+			_portalInstances.put(company.getCompanyId(), company.getWebId());
+		}
+	}
+
 	public static long getCompanyId(String webId) {
 		if (!_portalInstances.isEmpty()) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -23,6 +23,17 @@ public class PortalInstancePool {
 		_portalInstances.put(company.getCompanyId(), company.getWebId());
 	}
 
+	public static long getCompanyId(String webId) {
+		for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
+			if (Objects.equals(entry.getValue(), webId)) {
+				return entry.getKey();
+			}
+		}
+
+		throw new IllegalArgumentException(
+			"Unable to get company ID with web ID" + webId);
+	}
+
 	public static long[] getCompanyIds() {
 		return ArrayUtil.toLongArray(_portalInstances.keySet());
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -33,12 +33,6 @@ public class PortalInstancePool {
 		_portalInstances.put(company.getCompanyId(), company.getWebId());
 	}
 
-	public static void add(List<Company> companies) {
-		for (Company company : companies) {
-			_portalInstances.put(company.getCompanyId(), company.getWebId());
-		}
-	}
-
 	public static long getCompanyId(String webId) {
 		if (!_portalInstances.isEmpty()) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
@@ -138,6 +132,16 @@ public class PortalInstancePool {
 
 	public static void remove(long companyId) {
 		_portalInstances.remove(companyId);
+	}
+
+	public static void set(List<Company> companies) {
+		Map<Long, String> portalInstances = new ConcurrentHashMap<>();
+
+		for (Company company : companies) {
+			portalInstances.put(company.getCompanyId(), company.getWebId());
+		}
+
+		_portalInstances = portalInstances;
 	}
 
 	private static long _getCompanyIdBySQL(String webId) throws SQLException {
@@ -241,7 +245,7 @@ public class PortalInstancePool {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstancePool.class);
 
-	private static final Map<Long, String> _portalInstances =
+	private static Map<Long, String> _portalInstances =
 		new ConcurrentHashMap<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -30,11 +30,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PortalInstancePool {
 
 	public static void add(Company company) {
-		_portalInstances.put(company.getCompanyId(), company.getWebId());
+		if (_portalInstances != null) {
+			_portalInstances.put(company.getCompanyId(), company.getWebId());
+		}
 	}
 
 	public static long getCompanyId(String webId) {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
 				if (Objects.equals(entry.getValue(), webId)) {
 					return entry.getKey();
@@ -58,7 +60,7 @@ public class PortalInstancePool {
 	}
 
 	public static long[] getCompanyIds() {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			return ArrayUtil.toLongArray(_portalInstances.keySet());
 		}
 
@@ -73,7 +75,7 @@ public class PortalInstancePool {
 	}
 
 	public static long getDefaultCompanyId() {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
 				if (Objects.equals(
 						PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID),
@@ -98,7 +100,7 @@ public class PortalInstancePool {
 	}
 
 	public static String getWebId(long companyId) {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			return _portalInstances.get(companyId);
 		}
 
@@ -116,7 +118,7 @@ public class PortalInstancePool {
 	}
 
 	public static String[] getWebIds() {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			return ArrayUtil.toStringArray(_portalInstances.values());
 		}
 
@@ -131,7 +133,9 @@ public class PortalInstancePool {
 	}
 
 	public static void remove(long companyId) {
-		_portalInstances.remove(companyId);
+		if (_portalInstances != null) {
+			_portalInstances.remove(companyId);
+		}
 	}
 
 	public static void set(List<Company> companies) {
@@ -245,7 +249,6 @@ public class PortalInstancePool {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstancePool.class);
 
-	private static Map<Long, String> _portalInstances =
-		new ConcurrentHashMap<>();
+	private static Map<Long, String> _portalInstances;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/spring/orm/LastSessionRecorderHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/spring/orm/LastSessionRecorderHelperUtil.java
@@ -11,11 +11,15 @@ package com.liferay.portal.kernel.spring.orm;
 public class LastSessionRecorderHelperUtil {
 
 	public static void syncLastSessionState() {
-		_lastSessionRecorderHelper.syncLastSessionState();
+		if (_lastSessionRecorderHelper != null) {
+			_lastSessionRecorderHelper.syncLastSessionState();
+		}
 	}
 
 	public static void syncLastSessionState(boolean portalSessionOnly) {
-		_lastSessionRecorderHelper.syncLastSessionState(portalSessionOnly);
+		if (_lastSessionRecorderHelper != null) {
+			_lastSessionRecorderHelper.syncLastSessionState(portalSessionOnly);
+		}
 	}
 
 	public void setLastSessionRecorderHelper(

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 22.0.0
+version 22.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 13.1.0

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -13,8 +13,8 @@
 		<suppress checks="CamelCaseNameCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/ListUtilTest\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
-		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector\.java" />
+		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess\.java" />
 		<suppress checks="ConcatCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/StringBundlerTest\.java" />
 		<suppress checks="ConstantNameCheck" files="portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor\.java" />


### PR DESCRIPTION
- LPS-194500 Simplifying logic to know if a table is a control table or not
- LPS-194500 Adding new method to know if the given table name is a view in the target database. This prevents an error when dealing with views during the upgrade since we have change the isControlTable method logic.
- LPS-194500 We need to browse all the partitions when loading properties from database
- LPS-194500 If the database is new, return immediately to create the database
- LPS-194500 When loading configurations through DBPartitionUtil Spring has not been initialized, giving a NPE
- LPS-194500 Passing DataSource reference to the class to be able to perform some checks on DB
- LPS-194500 When a configuration file is added, modified or deleted with Database Partitioning, if it is a scoped configuration, it is needed to properly set the CompanyThreadLocal before persisting it in the database
- LPS-194500 SF, fix typo
- LPS-194500 Modifying API to allow the copy of the data in the new created tables or not
- LPS-194500 Applying new API
- LPS-194500 Adding new upgrade process for the Configuration_ table
- LPS-194500 When configuration is deleted through the UI, at this point it has already been deleted, but the watcher is fired because it also deleted the file, so no need to set any company thread local
- LPS-194500 It is the start method the one who should know when to create the table and when to populate the dictionaries
- LPS-194500 We should not handle the dataSource in this module and we really don't need it (it depends on next commit)
- LPS-194500 Set CompanyThreadLocal when loading configuration files when DB Partition is enabled. Do not allow portletInstance or group scoped configuration via config file since it is not needed for LXC and makes the process much more complex
- LPS-194500 Rename
- LPS-194500 Refactor upgrade process
- LPS-194500 Adding test to check that when DB Partitioning is enabled, Configuration_ table is empty by default on new partitions
- LPS-194500 Adding tests for all the available scoped configurations by file
- LPS-194500 Fix issue after rebase
- LPS-194500 As now the configuration installer checks the companyId exists for company scoped configurations, it is needed to create the partitions and initialize the data properly
- LPS-194500 Improve base test case adding initialization logic to the right methods
- LPS-194500 Adding configuration file tests for DB Partitioning
- LPS-194500 Fixing issue on upgrade process due to conversion types
- LPS-194500 Adding tests for upgrade process
- LPS-194500 When coming from 6.1 or 6.2 the database is not new, but the Configuration_ table does not exist
- LPS-194500 Full cleanup on tests
- LPS-194500 Connection isn't thread safe. Ask dataSource for a connection per thread.
- LPS-194500 GroupTestUtil uses TestPropsValues.getUserId(), which in the context of CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0]) doesn't exist and only will be retrieved if it's cached. This can originate flaky tests.
- LPS-194500 Use constants.
- LPS-194500 Create new method to simulate partitions as real as possible simplifying the API and the knowledge of which methods should/shouldn't be invoked each time.
- LPS-194500 Apply new methods to setUp/tearDown partitions.
- LPS-194500 Semantic Versioning
- LPS-194500 Unifying getCompanyXXX methods in PortalInstancePool class to avoid code duplications
- LPS-194500 Now it is needed to initialize the PortalInstancePool at once
- LPS-194500 Replacing usages of deprecated APIs
- LPS-194500 Fixing test by adding convenience method
- LPS-194500 Baseline
- LPS-194500 Auto SF
- LPS-194500 Changing configuration parameter name to avoid it to be considered a scoped configuration
- LPS-194500 This method is not needed
- LPS-194500 We can't have concurrent issues here
- LPS-194500 Update SF rule
- LPS-194500 SF
- LPS-194500 Making the _portalInstances array initialization atomic
- LPS-194500 Baseline
- LPS-194500 PortalInstancePool is initialized with the set method, until it is not called, all the methods check against the database
