### PR TITLE
LPS-206629 Centralize portal instances loading logic in PortalInstancePool

### DIFF
--- a/modules/apps/asset/asset-publisher-layout-prototype/src/main/java/com/liferay/asset/publisher/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/asset/asset-publisher-layout-prototype/src/main/java/com/liferay/asset/publisher/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.asset.publisher.layout.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER, "LayoutPrototype",

--- a/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/blogs/blogs-layout-prototype/src/main/java/com/liferay/blogs/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.blogs.layout.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER, "LayoutPrototype",

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -10,6 +10,7 @@ import com.liferay.portal.db.partition.db.DBPartitionDB;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -31,7 +32,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -91,14 +91,14 @@ public class CompanyLocalServiceDBPartitionTest
 
 		Assert.assertTrue(
 			ArrayUtil.contains(
-				PortalInstances.getCompanyIdsBySQL(), _company.getCompanyId()));
+				PortalInstancePool.getCompanyIds(), _company.getCompanyId()));
 
 		Assert.assertEquals(dbPartitionsCount + 1, _getDBPartitionsCount());
 	}
 
 	@Test
 	public void testAddCompanyWhenCompanyLocalServiceFails() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 		int dbPartitionsCount = _getDBPartitionsCount();
 
 		Company company = null;
@@ -120,7 +120,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 		catch (Exception exception) {
 			Assert.assertArrayEquals(
-				companyIds, PortalInstances.getCompanyIdsBySQL());
+				companyIds, PortalInstancePool.getCompanyIds());
 			Assert.assertEquals(dbPartitionsCount, _getDBPartitionsCount());
 		}
 		finally {
@@ -132,7 +132,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 	@Test
 	public void testAddCompanyWhenDBPartitionUtilFails() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 		int dbPartitionsCount = _getDBPartitionsCount();
 
 		Company company = null;
@@ -159,7 +159,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 		catch (Exception exception) {
 			Assert.assertArrayEquals(
-				companyIds, PortalInstances.getCompanyIdsBySQL());
+				companyIds, PortalInstancePool.getCompanyIds());
 			Assert.assertEquals(dbPartitionsCount, _getDBPartitionsCount());
 		}
 		finally {
@@ -187,7 +187,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 			standaloneDBPartition = false;
 
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			Assert.assertTrue(
 				ArrayUtil.contains(companyIds, company.getCompanyId()));
@@ -221,7 +221,7 @@ public class CompanyLocalServiceDBPartitionTest
 			standaloneDBPartition = true;
 
 			Company defaultCompany = _companyLocalService.getCompany(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			try {
 				_companyLocalService.addDBPartitionCompany(
@@ -233,10 +233,10 @@ public class CompanyLocalServiceDBPartitionTest
 				Assert.fail();
 			}
 			catch (PortalException portalException) {
-				long[] companyIds = PortalInstances.getCompanyIdsBySQL();
-
 				Assert.assertFalse(
-					ArrayUtil.contains(companyIds, company.getCompanyId()));
+					ArrayUtil.contains(
+						PortalInstancePool.getCompanyIds(),
+						company.getCompanyId()));
 
 				_checkStandaloneDBPartitionTables(
 					company.getCompanyId(), "Company", "VirtualHost");
@@ -292,7 +292,7 @@ public class CompanyLocalServiceDBPartitionTest
 				Assert.fail();
 			}
 			catch (PortalException portalException) {
-				long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+				long[] companyIds = PortalInstancePool.getCompanyIds();
 
 				Assert.assertFalse(
 					ArrayUtil.contains(companyIds, company.getCompanyId()));
@@ -321,7 +321,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 		Assert.assertFalse(
 			ArrayUtil.contains(
-				PortalInstances.getCompanyIdsBySQL(), company.getCompanyId()));
+				PortalInstancePool.getCompanyIds(), company.getCompanyId()));
 		Assert.assertEquals(dbPartitionsCount - 1, _getDBPartitionsCount());
 	}
 
@@ -352,7 +352,7 @@ public class CompanyLocalServiceDBPartitionTest
 		catch (Exception exception) {
 			Assert.assertTrue(
 				ArrayUtil.contains(
-					PortalInstances.getCompanyIdsBySQL(),
+					PortalInstancePool.getCompanyIds(),
 					_company.getCompanyId()));
 		}
 	}
@@ -369,7 +369,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 			Assert.assertFalse(
 				ArrayUtil.contains(
-					PortalInstances.getCompanyIdsBySQL(),
+					PortalInstancePool.getCompanyIds(),
 					company.getCompanyId()));
 
 			standaloneDBPartition = true;
@@ -430,7 +430,7 @@ public class CompanyLocalServiceDBPartitionTest
 				viewsCount, _getViewsCount(company.getCompanyId()));
 			Assert.assertTrue(
 				ArrayUtil.contains(
-					PortalInstances.getCompanyIdsBySQL(),
+					PortalInstancePool.getCompanyIds(),
 					company.getCompanyId()));
 		}
 		finally {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -90,15 +90,14 @@ public class CompanyLocalServiceDBPartitionTest
 		_company = CompanyTestUtil.addCompany();
 
 		Assert.assertTrue(
-			ArrayUtil.contains(
-				PortalInstancePool.getCompanyIds(), _company.getCompanyId()));
+			ArrayUtil.contains(getCompanyIds(), _company.getCompanyId()));
 
 		Assert.assertEquals(dbPartitionsCount + 1, _getDBPartitionsCount());
 	}
 
 	@Test
 	public void testAddCompanyWhenCompanyLocalServiceFails() throws Exception {
-		long[] companyIds = PortalInstancePool.getCompanyIds();
+		long[] companyIds = getCompanyIds();
 		int dbPartitionsCount = _getDBPartitionsCount();
 
 		Company company = null;
@@ -119,8 +118,7 @@ public class CompanyLocalServiceDBPartitionTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			Assert.assertArrayEquals(
-				companyIds, PortalInstancePool.getCompanyIds());
+			Assert.assertArrayEquals(companyIds, getCompanyIds());
 			Assert.assertEquals(dbPartitionsCount, _getDBPartitionsCount());
 		}
 		finally {
@@ -132,7 +130,7 @@ public class CompanyLocalServiceDBPartitionTest
 
 	@Test
 	public void testAddCompanyWhenDBPartitionUtilFails() throws Exception {
-		long[] companyIds = PortalInstancePool.getCompanyIds();
+		long[] companyIds = getCompanyIds();
 		int dbPartitionsCount = _getDBPartitionsCount();
 
 		Company company = null;
@@ -158,8 +156,7 @@ public class CompanyLocalServiceDBPartitionTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			Assert.assertArrayEquals(
-				companyIds, PortalInstancePool.getCompanyIds());
+			Assert.assertArrayEquals(companyIds, getCompanyIds());
 			Assert.assertEquals(dbPartitionsCount, _getDBPartitionsCount());
 		}
 		finally {
@@ -187,10 +184,8 @@ public class CompanyLocalServiceDBPartitionTest
 
 			standaloneDBPartition = false;
 
-			long[] companyIds = PortalInstancePool.getCompanyIds();
-
 			Assert.assertTrue(
-				ArrayUtil.contains(companyIds, company.getCompanyId()));
+				ArrayUtil.contains(getCompanyIds(), company.getCompanyId()));
 
 			Assert.assertEquals(name, company.getName());
 			Assert.assertEquals(virtualHostName, company.getVirtualHostname());
@@ -235,8 +230,7 @@ public class CompanyLocalServiceDBPartitionTest
 			catch (PortalException portalException) {
 				Assert.assertFalse(
 					ArrayUtil.contains(
-						PortalInstancePool.getCompanyIds(),
-						company.getCompanyId()));
+						getCompanyIds(), company.getCompanyId()));
 
 				_checkStandaloneDBPartitionTables(
 					company.getCompanyId(), "Company", "VirtualHost");
@@ -292,10 +286,9 @@ public class CompanyLocalServiceDBPartitionTest
 				Assert.fail();
 			}
 			catch (PortalException portalException) {
-				long[] companyIds = PortalInstancePool.getCompanyIds();
-
 				Assert.assertFalse(
-					ArrayUtil.contains(companyIds, company.getCompanyId()));
+					ArrayUtil.contains(
+						getCompanyIds(), company.getCompanyId()));
 
 				_checkStandaloneDBPartitionTables(
 					company.getCompanyId(), "Company", "VirtualHost");
@@ -320,8 +313,7 @@ public class CompanyLocalServiceDBPartitionTest
 		_companyLocalService.deleteCompany(company);
 
 		Assert.assertFalse(
-			ArrayUtil.contains(
-				PortalInstancePool.getCompanyIds(), company.getCompanyId()));
+			ArrayUtil.contains(getCompanyIds(), company.getCompanyId()));
 		Assert.assertEquals(dbPartitionsCount - 1, _getDBPartitionsCount());
 	}
 
@@ -351,9 +343,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 		catch (Exception exception) {
 			Assert.assertTrue(
-				ArrayUtil.contains(
-					PortalInstancePool.getCompanyIds(),
-					_company.getCompanyId()));
+				ArrayUtil.contains(getCompanyIds(), _company.getCompanyId()));
 		}
 	}
 
@@ -368,9 +358,7 @@ public class CompanyLocalServiceDBPartitionTest
 				company.getCompanyId());
 
 			Assert.assertFalse(
-				ArrayUtil.contains(
-					PortalInstancePool.getCompanyIds(),
-					company.getCompanyId()));
+				ArrayUtil.contains(getCompanyIds(), company.getCompanyId()));
 
 			standaloneDBPartition = true;
 
@@ -429,9 +417,7 @@ public class CompanyLocalServiceDBPartitionTest
 			Assert.assertEquals(
 				viewsCount, _getViewsCount(company.getCompanyId()));
 			Assert.assertTrue(
-				ArrayUtil.contains(
-					PortalInstancePool.getCompanyIds(),
-					company.getCompanyId()));
+				ArrayUtil.contains(getCompanyIds(), company.getCompanyId()));
 		}
 		finally {
 			if (standaloneDBPartition) {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.NoSuchPasswordPolicyException;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -183,7 +184,7 @@ public class CompanyLocalServiceTest {
 
 		_companyLocalService.deleteCompany(company.getCompanyId());
 
-		for (String webId : PortalInstances.getWebIds()) {
+		for (String webId : PortalInstancePool.getWebIds()) {
 			Assert.assertNotEquals(company.getWebId(), webId);
 		}
 	}
@@ -772,7 +773,7 @@ public class CompanyLocalServiceTest {
 
 	@Test(expected = RequiredCompanyException.class)
 	public void testDeleteDefaultCompany() throws Exception {
-		long companyId = PortalInstances.getDefaultCompanyId();
+		long companyId = PortalInstancePool.getDefaultCompanyId();
 
 		_companyLocalService.deleteCompany(companyId);
 	}
@@ -798,7 +799,7 @@ public class CompanyLocalServiceTest {
 	public void testExtractDBPartitionCompanyDefaultCompany() {
 		try {
 			_companyLocalService.extractDBPartitionCompany(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			Assert.fail();
 		}

--- a/modules/apps/document-library/document-library-layout-set-prototype/src/main/java/com/liferay/document/library/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/document-library/document-library-layout-set-prototype/src/main/java/com/liferay/document/library/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.document.library.layout.set.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER,

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentCollectionsDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.fragment.service.FragmentCollectionServiceUtil;
 import com.liferay.fragment.web.internal.util.FragmentPortletUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
@@ -20,7 +21,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.util.PortalInstances;
 
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
@@ -97,7 +97,7 @@ public class FragmentCollectionsDisplayContext {
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
 		if ((themeDisplay.getCompanyId() ==
-				PortalInstances.getDefaultCompanyId()) &&
+				PortalInstancePool.getDefaultCompanyId()) &&
 			scopeGroup.isCompany()) {
 
 			groupIds = ArrayUtil.append(groupIds, CompanyConstants.SYSTEM);

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -51,7 +52,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -734,7 +734,7 @@ public class FragmentDisplayContext {
 
 		if ((fragmentCollection.getGroupId() == CompanyConstants.SYSTEM) &&
 			((_themeDisplay.getCompanyId() !=
-				PortalInstances.getDefaultCompanyId()) ||
+				PortalInstancePool.getDefaultCompanyId()) ||
 			 !scopeGroup.isCompany())) {
 
 			return true;

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -10,6 +10,7 @@ import com.liferay.layout.utility.page.kernel.request.contributor.StatusLayoutUt
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -32,7 +33,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
@@ -151,7 +151,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			companyId = virtualHost.getCompanyId();
 		}
 		else {
-			companyId = PortalInstances.getDefaultCompanyId();
+			companyId = PortalInstancePool.getDefaultCompanyId();
 		}
 
 		Group group = _groupLocalService.fetchFriendlyURLGroup(

--- a/modules/apps/message-boards/message-boards-layout-set-prototype/src/main/java/com/liferay/message/boards/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/message-boards/message-boards-layout-set-prototype/src/main/java/com/liferay/message/boards/layout/set/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.message.boards.layout.set.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER,

--- a/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/helper/OnDemandAdminHelper.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/helper/OnDemandAdminHelper.java
@@ -8,6 +8,7 @@ package com.liferay.on.demand.admin.internal.helper;
 import com.liferay.on.demand.admin.constants.OnDemandAdminActionKeys;
 import com.liferay.on.demand.admin.constants.OnDemandAdminPortletKeys;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.User;
@@ -15,7 +16,6 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
-import com.liferay.portal.util.PortalInstances;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -30,14 +30,14 @@ public class OnDemandAdminHelper {
 			long companyId, long userId)
 		throws PortalException {
 
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new PrincipalException(
 				"Target company must not be the default company");
 		}
 
 		User user = _userLocalService.getUser(userId);
 
-		if (user.getCompanyId() != PortalInstances.getDefaultCompanyId()) {
+		if (user.getCompanyId() != PortalInstancePool.getDefaultCompanyId()) {
 			throw new PrincipalException(
 				"Request can only be made from the default company");
 		}

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.instances.service.base.PortalInstancesLocalServiceBaseImpl;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -84,12 +85,12 @@ public class PortalInstancesLocalServiceImpl
 
 	@Override
 	public long[] getCompanyIds() {
-		return PortalInstances.getCompanyIds();
+		return PortalInstancePool.getCompanyIds();
 	}
 
 	@Override
 	public long getDefaultCompanyId() {
-		return PortalInstances.getDefaultCompanyId();
+		return PortalInstancePool.getDefaultCompanyId();
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/BackupAndRestoreIndexesTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/BackupAndRestoreIndexesTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.IndexAdminHelper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -15,7 +16,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +40,7 @@ public class BackupAndRestoreIndexesTest {
 	public void testBackupAndRestore() throws Exception {
 		Map<Long, String> backupNames = new HashMap<>();
 
-		for (long companyId : PortalInstances.getCompanyIds()) {
+		for (long companyId : PortalInstancePool.getCompanyIds()) {
 			String backupName = StringUtil.lowerCase(
 				BackupAndRestoreIndexesTest.class.getName());
 

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -46,6 +46,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import java.util.Map;
+
 import javax.sql.DataSource;
 
 import org.junit.Assume;
@@ -417,6 +419,20 @@ public abstract class BaseDBPartitionTestCase {
 				StringBundler.concat(
 					"insert into ", tableName, " values (1, ",
 					CompanyThreadLocal.getCompanyId(), ")"));
+		}
+	}
+
+	protected long[] getCompanyIds() {
+		Map<Long, String> portalInstances =
+			ReflectionTestUtil.getAndSetFieldValue(
+				PortalInstancePool.class, "_portalInstances", null);
+
+		try {
+			return PortalInstancePool.getCompanyIds();
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				PortalInstancePool.class, "_portalInstances", portalInstances);
 		}
 	}
 

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.module.util.BundleUtil;
@@ -38,7 +39,6 @@ import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
@@ -182,7 +182,8 @@ public abstract class BaseDBPartitionTestCase {
 	}
 
 	protected static void enableDBPartition() throws Exception {
-		CompanyThreadLocal.setCompanyId(PortalInstances.getDefaultCompanyId());
+		CompanyThreadLocal.setCompanyId(
+			PortalInstancePool.getDefaultCompanyId());
 
 		_dbPartitionEnabled = DBPartition.isPartitionEnabled();
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertVirtualInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertVirtualInstanceOperationTest.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.db.partition.internal.operation.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +28,7 @@ public class DBPartitionInsertVirtualInstanceOperationTest
 		deployConfiguration(
 			_PID,
 			"newWebId=T\"testNewWebId\"\ncompanyId=L\"" +
-				PortalInstances.getDefaultCompanyId() + "\"\n");
+				PortalInstancePool.getDefaultCompanyId() + "\"\n");
 
 		verifyConfigurationIsDeletedAfterDeploy(_PID);
 	}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -28,7 +29,6 @@ import com.liferay.portal.model.impl.ResourceActionImpl;
 import com.liferay.portal.service.impl.ClassNameLocalServiceImpl;
 import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -397,7 +397,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 		dbPartitionUpgradeProcess.upgrade();
 
-		long[] expectedCompanyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] expectedCompanyIds = PortalInstancePool.getCompanyIds();
 
 		Arrays.sort(expectedCompanyIds);
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -12,7 +12,6 @@ import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -397,7 +396,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 		dbPartitionUpgradeProcess.upgrade();
 
-		long[] expectedCompanyIds = PortalInstancePool.getCompanyIds();
+		long[] expectedCompanyIds = getCompanyIds();
 
 		Arrays.sort(expectedCompanyIds);
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
@@ -10,10 +10,10 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.upgrade.util.UpgradePartitionedControlTable;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -122,7 +122,7 @@ public class UpgradePartitionedControlTableTest
 
 			DBPartitionUtil.forEachCompanyId(
 				companyId -> {
-					if (PortalInstances.getDefaultCompanyId() ==
+					if (PortalInstancePool.getDefaultCompanyId() ==
 							DBPartitionUtil.getCurrentCompanyId()) {
 
 						return;

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
@@ -169,7 +170,8 @@ public class PortalInstancesTest {
 	public void testGetWebIdsAfterInitCompany() {
 		PortalInstances.initCompany(_company);
 
-		List<String> webIds = ListUtil.fromArray(PortalInstances.getWebIds());
+		List<String> webIds = ListUtil.fromArray(
+			PortalInstancePool.getWebIds());
 
 		Assert.assertTrue(webIds.contains(_company.getWebId()));
 
@@ -178,7 +180,7 @@ public class PortalInstancesTest {
 		PortalInstances.initCompany(
 			_companyLocalService.updateCompany(_company));
 
-		webIds = ListUtil.fromArray(PortalInstances.getWebIds());
+		webIds = ListUtil.fromArray(PortalInstancePool.getWebIds());
 
 		Assert.assertTrue(webIds.contains(_company.getWebId()));
 	}

--- a/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
+++ b/modules/apps/wiki/wiki-layout-prototype/src/main/java/com/liferay/wiki/layout/prototype/internal/upgrade/v1_0_0/UpgradeLocalizedColumn.java
@@ -5,9 +5,9 @@
 
 package com.liferay.wiki.layout.prototype.internal.upgrade.v1_0_0;
 
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseLocalizedColumnUpgradeProcess;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Leon Chi
@@ -16,7 +16,7 @@ public class UpgradeLocalizedColumn extends BaseLocalizedColumnUpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		upgradeLocalizedColumn(
 			LanguageResources.PORTAL_RESOURCE_BUNDLE_LOADER, "LayoutPrototype",

--- a/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultCompanyNameSwapper.java
+++ b/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultCompanyNameSwapper.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.properties.swapper.internal;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -13,7 +14,6 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Objects;
@@ -40,7 +40,7 @@ public class DefaultCompanyNameSwapper {
 
 		try {
 			Company defaultCompany = _companyLocalService.getCompany(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			if (!_hasCustomCompanyName(
 					defaultCompany, originalCompanyDefaultName)) {

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -202,7 +202,7 @@
 			<property name="enabled" value="false" />
 			<message key="company.local.service.use.for.loop" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
 			<message key="company.local.service.use.sql" value="Use ''CompanyLocalService.forEachCompany'' instead of SQL" />
-			<message key="portal.instances.use" value="Use ''PortalInstances.getCompanyIdsBySQL'' instead to fetch company IDs" />
+			<message key="portal.instances.use" value="Use ''PortalInstancePool.getCompanyIds'' instead to fetch company IDs" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ConcatCheck">
 			<property name="category" value="Performance" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -272,7 +272,7 @@
 			<property name="enabled" value="false" />
 			<message key="company.local.service.use.for.loop" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
 			<message key="company.local.service.use.sql" value="Use ''CompanyLocalService.forEachCompany'' instead of SQL" />
-			<message key="portal.instances.use" value="Use ''PortalInstances.getCompanyIdsBySQL'' instead to fetch company IDs" />
+			<message key="portal.instances.use" value="Use ''PortalInstancePool.getCompanyIds'' instead to fetch company IDs" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ComponentAnnotationCheck">
 			<property name="category" value="Bug Prevention" />

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -34,7 +35,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.spring.hibernate.DialectDetector;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.sql.Connection;
@@ -564,7 +564,7 @@ public class DBPartitionUtil {
 
 	private static List<Long> _getCompanyIds() throws SQLException {
 		if (_companyIds.isEmpty()) {
-			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+			for (long companyId : PortalInstancePool.getCompanyIds()) {
 				_companyIds.add(companyId);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -788,6 +789,8 @@ public class MainServlet extends HttpServlet {
 			throw new RuntimeException("Company default web ID is null");
 		}
 
+		List<Company> companies = new ArrayList<>();
+
 		CompanyLocalServiceUtil.forEachCompany(
 			company -> {
 				if (StartupHelperUtil.isDBNew() &&
@@ -800,7 +803,11 @@ public class MainServlet extends HttpServlet {
 				else {
 					PortalInstances.initCompany(company, false);
 				}
+
+				companies.add(company);
 			});
+
+		PortalInstancePool.set(companies);
 	}
 
 	private void _initLayoutTemplates(PluginPackage pluginPackage) {

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -410,7 +410,7 @@ public class MainServlet extends HttpServlet {
 
 			try {
 				SetupWizardSampleDataUtil.addSampleData(
-					PortalInstances.getDefaultCompanyId());
+					PortalInstancePool.getDefaultCompanyId());
 			}
 			catch (Exception exception) {
 				_log.error(exception);

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.instance.lifecycle.PortalInstanceLifecycleManager;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -353,7 +354,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				"Database partition must be enabled");
 		}
 
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new IllegalArgumentException(
 				"Company ID " + companyId + " is the default company ID");
 		}
@@ -496,7 +497,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 	@Override
 	public Company deleteCompany(long companyId) throws PortalException {
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new RequiredCompanyException(
 				"Select another default company before deleting company " +
 					companyId);
@@ -541,7 +542,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				"Database partition must be enabled");
 		}
 
-		if (companyId == PortalInstances.getDefaultCompanyId()) {
+		if (companyId == PortalInstancePool.getDefaultCompanyId()) {
 			throw new RequiredCompanyException(
 				"Select another default company before extracting company " +
 					companyId);
@@ -802,7 +803,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	 */
 	@Override
 	public long getCompanyIdByUserId(long userId) throws Exception {
-		long[] companyIds = PortalInstances.getCompanyIds();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		long companyId = 0;
 
@@ -944,7 +945,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		virtualHostname = StringUtil.toLowerCase(
 			StringUtil.trim(virtualHostname));
 
-		if (!active && (companyId == PortalInstances.getDefaultCompanyId())) {
+		if (!active &&
+			(companyId == PortalInstancePool.getDefaultCompanyId())) {
+
 			throw new RequiredCompanyException(
 				"Select another default company before deactivating company " +
 					companyId);
@@ -2275,7 +2278,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
 
 		while ((nextLong == 0) ||
-			   ArrayUtil.contains(PortalInstances.getCompanyIds(), nextLong)) {
+			   ArrayUtil.contains(
+				   PortalInstancePool.getCompanyIds(), nextLong)) {
 
 			nextLong = threadLocalRandom.nextLong(
 				(long)Math.pow(10, 15), Long.MAX_VALUE);

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceMode;
 import com.liferay.portal.kernel.model.Country;
@@ -17,7 +18,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.base.CountryServiceBaseImpl;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.List;
 
@@ -88,7 +88,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country fetchCountryByA2(String a2) {
-		return fetchCountryByA2(PortalInstances.getDefaultCompanyId(), a2);
+		return fetchCountryByA2(PortalInstancePool.getDefaultCompanyId(), a2);
 	}
 
 	@Override
@@ -102,7 +102,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country fetchCountryByA3(String a3) {
-		return fetchCountryByA3(PortalInstances.getDefaultCompanyId(), a3);
+		return fetchCountryByA3(PortalInstancePool.getDefaultCompanyId(), a3);
 	}
 
 	@Override
@@ -150,7 +150,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public List<Country> getCountries() {
-		return getCompanyCountries(PortalInstances.getDefaultCompanyId());
+		return getCompanyCountries(PortalInstancePool.getDefaultCompanyId());
 	}
 
 	/**
@@ -161,7 +161,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Override
 	public List<Country> getCountries(boolean active) {
 		return getCompanyCountries(
-			PortalInstances.getDefaultCompanyId(), active);
+			PortalInstancePool.getDefaultCompanyId(), active);
 	}
 
 	@Override
@@ -182,7 +182,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country getCountryByA2(String a2) throws PortalException {
-		return getCountryByA2(PortalInstances.getDefaultCompanyId(), a2);
+		return getCountryByA2(PortalInstancePool.getDefaultCompanyId(), a2);
 	}
 
 	@Override
@@ -198,7 +198,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country getCountryByA3(String a3) throws PortalException {
-		return getCountryByA3(PortalInstances.getDefaultCompanyId(), a3);
+		return getCountryByA3(PortalInstancePool.getDefaultCompanyId(), a3);
 	}
 
 	@Override
@@ -214,7 +214,7 @@ public class CountryServiceImpl extends CountryServiceBaseImpl {
 	@Deprecated
 	@Override
 	public Country getCountryByName(String name) throws PortalException {
-		return getCountryByName(PortalInstances.getDefaultCompanyId(), name);
+		return getCountryByName(PortalInstancePool.getDefaultCompanyId(), name);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
+++ b/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
@@ -11,6 +11,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -72,7 +73,7 @@ public class SetupWizardUtil {
 	public static String getDefaultTimeZoneId() {
 		try {
 			Company company = CompanyLocalServiceUtil.getCompanyById(
-				PortalInstances.getDefaultCompanyId());
+				PortalInstancePool.getDefaultCompanyId());
 
 			User guestUser = company.getGuestUser();
 
@@ -143,7 +144,7 @@ public class SetupWizardUtil {
 			httpServletRequest, "companyTimeZoneId", getDefaultTimeZoneId());
 
 		CompanyLocalServiceUtil.updateDisplay(
-			PortalInstances.getDefaultCompanyId(), languageId, timeZoneId);
+			PortalInstancePool.getDefaultCompanyId(), languageId, timeZoneId);
 
 		_updateLanguage(
 			httpServletRequest, httpServletResponse, languageId, locale);
@@ -406,7 +407,7 @@ public class SetupWizardUtil {
 		throws Exception {
 
 		Company company = CompanyLocalServiceUtil.getCompanyById(
-			PortalInstances.getDefaultCompanyId());
+			PortalInstancePool.getDefaultCompanyId());
 
 		String languageId = ParamUtil.getString(
 			httpServletRequest, "companyLocale", getDefaultLanguageId());

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeDocumentLibrary.java
@@ -10,6 +10,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.TreeModel;
@@ -27,7 +28,6 @@ import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.Serializable;
 
@@ -302,7 +302,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 		_runSQL("create index IX_LPP_41834_EYIW on DLFolder (userId);");
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			for (long companyId : companyIds) {
 				try (PreparedStatement folderPreparedStatement =

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeCompanyId.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.upgrade.v7_0_0;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseCompanyIdUpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.IOException;
 
@@ -152,7 +152,7 @@ public class UpgradeCompanyId extends BaseCompanyIdUpgradeProcess {
 		public void update(Connection connection)
 			throws IOException, SQLException {
 
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			if (companyIds.length == 1) {
 				runSQL(connection, getUpdateSQL(String.valueOf(companyIds[0])));

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -27,7 +28,6 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.LanguageResources;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortalPreferencesImpl;
 import com.liferay.portlet.PortalPreferencesWrapper;
@@ -59,7 +59,7 @@ public class UpgradeGroup extends UpgradeProcess {
 	}
 
 	protected void updateGlobalGroupName() throws Exception {
-		for (Long companyId : PortalInstances.getCompanyIdsBySQL()) {
+		for (Long companyId : PortalInstancePool.getCompanyIds()) {
 			LocalizedValuesMap localizedValuesMap = new LocalizedValuesMap();
 
 			for (String languageId : PropsValues.LOCALES_ENABLED) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradePortalPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradePortalPreferences.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.v7_0_5;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -17,7 +18,6 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,7 +34,7 @@ public class UpgradePortalPreferences extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			upgradePortalPreferences(PortletKeys.PREFS_OWNER_ID_DEFAULT);
 
-			for (long companyId : PortalInstances.getCompanyIdsBySQL()) {
+			for (long companyId : PortalInstancePool.getCompanyIds()) {
 				upgradePortalPreferences(companyId);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeCompanyId.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.BaseCompanyIdUpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.util.PortalInstances;
 
 import java.io.IOException;
 
@@ -56,7 +56,7 @@ public class UpgradeCompanyId extends BaseCompanyIdUpgradeProcess {
 		public void update(Connection connection)
 			throws IOException, SQLException {
 
-			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			if (companyIds.length == 1) {
 				runSQL(connection, getUpdateSQL(String.valueOf(companyIds[0])));

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeCompanyId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeCompanyId.java
@@ -7,6 +7,7 @@ package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -14,7 +15,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,7 +34,7 @@ public class UpgradeListTypeCompanyId extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long defaultCompanyId = PortalInstances.getDefaultCompanyIdBySQL();
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 
 		_resetCounter(defaultCompanyId);
 
@@ -167,7 +167,7 @@ public class UpgradeListTypeCompanyId extends UpgradeProcess {
 
 		runSQL("update ListType set companyId = " + defaultCompanyId);
 
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		List<ListTypeEntry> listTypeEntries = _getListTypes();
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeListTypeType.java
@@ -6,9 +6,9 @@
 package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -27,7 +27,7 @@ public class UpgradeListTypeType extends UpgradeProcess {
 			return;
 		}
 
-		long[] companyIds = PortalInstances.getCompanyIdsBySQL();
+		long[] companyIds = PortalInstancePool.getCompanyIds();
 
 		for (long companyId : companyIds) {
 			_updateListType(companyId, "intranet");

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RSSFeedException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.image.ImageBag;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.language.constants.LanguageConstants;
 import com.liferay.portal.kernel.log.Log;
@@ -1752,7 +1753,7 @@ public class PortalImpl implements Portal {
 
 			if (company == null) {
 				company = CompanyLocalServiceUtil.getCompanyById(
-					PortalInstances.getDefaultCompanyId());
+					PortalInstancePool.getDefaultCompanyId());
 			}
 
 			httpServletRequest.setAttribute(WebKeys.COMPANY, company);
@@ -1780,7 +1781,7 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public long[] getCompanyIds() {
-		return PortalInstances.getCompanyIds();
+		return PortalInstancePool.getCompanyIds();
 	}
 
 	@Override
@@ -2184,7 +2185,7 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public long getDefaultCompanyId() {
-		return PortalInstances.getDefaultCompanyId();
+		return PortalInstancePool.getDefaultCompanyId();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -125,7 +125,7 @@ public class PortalInstances {
 		}
 
 		if (companyId <= 0) {
-			companyId = getDefaultCompanyId();
+			companyId = PortalInstancePool.getDefaultCompanyId();
 
 			if (_log.isDebugEnabled()) {
 				_log.debug("Default company ID " + companyId);

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -10,7 +10,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -38,12 +36,8 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -177,70 +171,42 @@ public class PortalInstances {
 		return companyId;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getCompanyIds()}
+	 */
+	@Deprecated
 	public static long[] getCompanyIds() {
 		return PortalInstancePool.getCompanyIds();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getCompanyIds()}
+	 */
+	@Deprecated
 	public static long[] getCompanyIdsBySQL() throws SQLException {
-		List<Long> companyIds = new ArrayList<>();
-
-		long defaultCompanyId = getDefaultCompanyIdBySQL();
-
-		if (defaultCompanyId != 0) {
-			companyIds.add(defaultCompanyId);
-		}
-
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				_GET_COMPANY_IDS);
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
-
-				if (companyId != defaultCompanyId) {
-					companyIds.add(companyId);
-				}
-			}
-		}
-
-		return ArrayUtil.toArray(companyIds.toArray(new Long[0]));
+		return PortalInstancePool.getCompanyIds();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getDefaultCompanyId()}
+	 */
+	@Deprecated
 	public static long getDefaultCompanyId() {
-		long[] companyIds = PortalInstancePool.getCompanyIds();
-
-		if (companyIds.length == 0) {
-			try {
-				return getDefaultCompanyIdBySQL();
-			}
-			catch (SQLException sqlException) {
-				_log.error(
-					"Unable to get the default company ID by SQL",
-					sqlException);
-
-				throw new RuntimeException(sqlException);
-			}
-		}
-
 		return PortalInstancePool.getDefaultCompanyId();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getDefaultCompanyId()}
+	 */
+	@Deprecated
 	public static long getDefaultCompanyIdBySQL() throws SQLException {
-		try (Connection connection = DataAccess.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select companyId from Company where webId = '" +
-					PropsValues.COMPANY_DEFAULT_WEB_ID + "'");
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (resultSet.next()) {
-				return resultSet.getLong(1);
-			}
-		}
-
-		return 0;
+		return PortalInstancePool.getDefaultCompanyId();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link PortalInstancePool#getWebIds()} ()}
+	 */
+	@Deprecated
 	public static String[] getWebIds() {
 		return PortalInstancePool.getWebIds();
 	}
@@ -540,9 +506,6 @@ public class PortalInstances {
 
 	private PortalInstances() {
 	}
-
-	private static final String _GET_COMPANY_IDS =
-		"select companyId from Company";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstances.class);

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -33,7 +34,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.impl.GroupLocalServiceImpl;
-import com.liferay.portal.util.PortalInstances;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -342,7 +342,7 @@ public class VerifyGroup extends VerifyProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			CompanyLocalServiceUtil.forEachCompanyId(
 				companyId -> GroupLocalServiceUtil.rebuildTree(companyId),
-				PortalInstances.getCompanyIdsBySQL());
+				PortalInstancePool.getCompanyIds());
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyPermission.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyPermission.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -33,7 +34,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.HashMap;
 import java.util.List;
@@ -173,7 +173,7 @@ public class VerifyPermission extends VerifyProcess {
 			CompanyLocalServiceUtil.forEachCompanyId(
 				companyId -> fixUserDefaultRolePermissions(
 					userClassNameId, userGroupClassNameId, companyId),
-				PortalInstances.getCompanyIdsBySQL());
+				PortalInstancePool.getCompanyIds());
 		}
 		finally {
 			EntityCacheUtil.clearCache();

--- a/portal-impl/src/com/liferay/portal/verify/VerifyRole.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyRole.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.verify;
 
 import com.liferay.portal.kernel.exception.NoSuchRoleException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -19,7 +20,6 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
-import com.liferay.portal.util.PortalInstances;
 
 /**
  * @author Brian Wing Shun Chan
@@ -56,7 +56,7 @@ public class VerifyRole extends VerifyProcess {
 	protected void doVerify() throws Exception {
 		CompanyLocalServiceUtil.forEachCompanyId(
 			companyId -> verifyRoles(companyId),
-			PortalInstances.getCompanyIdsBySQL());
+			PortalInstancePool.getCompanyIds());
 	}
 
 	protected void verifyRoles(long companyId) throws Exception {

--- a/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
+++ b/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portlet.admin.util;
 
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -14,7 +15,6 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 /**
@@ -65,7 +65,7 @@ public class OmniadminUtil {
 				for (int i = 0; i < PropsValues.OMNIADMIN_USERS.length; i++) {
 					if (PropsValues.OMNIADMIN_USERS[i] == user.getUserId()) {
 						if (user.getCompanyId() !=
-								PortalInstances.getDefaultCompanyId()) {
+								PortalInstancePool.getDefaultCompanyId()) {
 
 							return false;
 						}
@@ -79,14 +79,14 @@ public class OmniadminUtil {
 
 			if (user.isGuestUser() ||
 				(user.getCompanyId() !=
-					PortalInstances.getDefaultCompanyId())) {
+					PortalInstancePool.getDefaultCompanyId())) {
 
 				return false;
 			}
 
 			try (SafeCloseable safeCloseable =
 					CompanyThreadLocal.setWithSafeCloseable(
-						PortalInstances.getDefaultCompanyId())) {
+						PortalInstancePool.getDefaultCompanyId())) {
 
 				return RoleLocalServiceUtil.hasUserRole(
 					user.getUserId(), user.getCompanyId(),

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -30,11 +30,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PortalInstancePool {
 
 	public static void add(Company company) {
-		_portalInstances.put(company.getCompanyId(), company.getWebId());
+		if (_portalInstances != null) {
+			_portalInstances.put(company.getCompanyId(), company.getWebId());
+		}
 	}
 
 	public static long getCompanyId(String webId) {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
 				if (Objects.equals(entry.getValue(), webId)) {
 					return entry.getKey();
@@ -58,7 +60,7 @@ public class PortalInstancePool {
 	}
 
 	public static long[] getCompanyIds() {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			return ArrayUtil.toLongArray(_portalInstances.keySet());
 		}
 
@@ -73,7 +75,7 @@ public class PortalInstancePool {
 	}
 
 	public static long getDefaultCompanyId() {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
 				if (Objects.equals(
 						PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID),
@@ -98,7 +100,7 @@ public class PortalInstancePool {
 	}
 
 	public static String getWebId(long companyId) {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			return _portalInstances.get(companyId);
 		}
 
@@ -116,7 +118,7 @@ public class PortalInstancePool {
 	}
 
 	public static String[] getWebIds() {
-		if (!_portalInstances.isEmpty()) {
+		if (_portalInstances != null) {
 			return ArrayUtil.toStringArray(_portalInstances.values());
 		}
 
@@ -131,7 +133,19 @@ public class PortalInstancePool {
 	}
 
 	public static void remove(long companyId) {
-		_portalInstances.remove(companyId);
+		if (_portalInstances != null) {
+			_portalInstances.remove(companyId);
+		}
+	}
+
+	public static void set(List<Company> companies) {
+		Map<Long, String> portalInstances = new ConcurrentHashMap<>();
+
+		for (Company company : companies) {
+			portalInstances.put(company.getCompanyId(), company.getWebId());
+		}
+
+		_portalInstances = portalInstances;
 	}
 
 	private static long _getCompanyIdBySQL(String webId) throws SQLException {
@@ -235,7 +249,6 @@ public class PortalInstancePool {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstancePool.class);
 
-	private static final Map<Long, String> _portalInstances =
-		new ConcurrentHashMap<>();
+	private static Map<Long, String> _portalInstances;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -5,11 +5,21 @@
 
 package com.liferay.portal.kernel.instance;
 
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,34 +33,207 @@ public class PortalInstancePool {
 		_portalInstances.put(company.getCompanyId(), company.getWebId());
 	}
 
+	public static long getCompanyId(String webId) {
+		if (!_portalInstances.isEmpty()) {
+			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
+				if (Objects.equals(entry.getValue(), webId)) {
+					return entry.getKey();
+				}
+			}
+
+			throw new IllegalArgumentException(
+				"Unable to get company ID with web ID" + webId);
+		}
+
+		try {
+			return _getCompanyIdBySQL(webId);
+		}
+		catch (SQLException sqlException) {
+			_log.error(
+				"Unable to get the company ID for webId " + webId + " by SQL",
+				sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
+	}
+
 	public static long[] getCompanyIds() {
-		return ArrayUtil.toLongArray(_portalInstances.keySet());
+		if (!_portalInstances.isEmpty()) {
+			return ArrayUtil.toLongArray(_portalInstances.keySet());
+		}
+
+		try {
+			return _getCompanyIdsBySQL();
+		}
+		catch (SQLException sqlException) {
+			_log.error("Unable to get the company IDs by SQL", sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
 	}
 
 	public static long getDefaultCompanyId() {
-		for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
-			if (Objects.equals(
-					PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID),
-					entry.getValue())) {
+		if (!_portalInstances.isEmpty()) {
+			for (Map.Entry<Long, String> entry : _portalInstances.entrySet()) {
+				if (Objects.equals(
+						PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID),
+						entry.getValue())) {
 
-				return entry.getKey();
+					return entry.getKey();
+				}
 			}
+
+			throw new IllegalStateException("Unable to get default company ID");
 		}
 
-		throw new IllegalStateException("Unable to get default company ID");
+		try {
+			return _getDefaultCompanyIdBySQL();
+		}
+		catch (SQLException sqlException) {
+			_log.error(
+				"Unable to get the default company ID by SQL", sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
 	}
 
 	public static String getWebId(long companyId) {
-		return _portalInstances.get(companyId);
+		if (!_portalInstances.isEmpty()) {
+			return _portalInstances.get(companyId);
+		}
+
+		try {
+			return _getWebIdBySQL(companyId);
+		}
+		catch (SQLException sqlException) {
+			_log.error(
+				"Unable to get the web ID for company with companyID " +
+					companyId + " by SQL",
+				sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
 	}
 
 	public static String[] getWebIds() {
-		return ArrayUtil.toStringArray(_portalInstances.values());
+		if (!_portalInstances.isEmpty()) {
+			return ArrayUtil.toStringArray(_portalInstances.values());
+		}
+
+		try {
+			return _getWebIdsBySQL();
+		}
+		catch (SQLException sqlException) {
+			_log.error("Unable to get the web IDs by SQL", sqlException);
+
+			throw new RuntimeException(sqlException);
+		}
 	}
 
 	public static void remove(long companyId) {
 		_portalInstances.remove(companyId);
 	}
+
+	private static long _getCompanyIdBySQL(String webId) throws SQLException {
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company where webId = ?")) {
+
+			preparedStatement.setString(1, webId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getLong(1);
+				}
+			}
+		}
+
+		throw new IllegalArgumentException(
+			"Unable to get company ID with web ID" + webId);
+	}
+
+	private static long[] _getCompanyIdsBySQL() throws SQLException {
+		List<Long> companyIds = new ArrayList<>();
+
+		long defaultCompanyId = _getDefaultCompanyIdBySQL();
+
+		if (defaultCompanyId != 0) {
+			companyIds.add(defaultCompanyId);
+		}
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+
+				if (companyId != defaultCompanyId) {
+					companyIds.add(companyId);
+				}
+			}
+		}
+
+		return ArrayUtil.toArray(companyIds.toArray(new Long[0]));
+	}
+
+	private static long _getDefaultCompanyIdBySQL() throws SQLException {
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId from Company where webId = '" +
+					_COMPANY_DEFAULT_WEB_ID + "'");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				return resultSet.getLong(1);
+			}
+		}
+
+		return 0;
+	}
+
+	private static String _getWebIdBySQL(long companyId) throws SQLException {
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select webId from Company where companyId = ?")) {
+
+			preparedStatement.setLong(1, companyId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getString(1);
+				}
+			}
+		}
+
+		throw new IllegalArgumentException(
+			"Unable to get web ID with company ID" + companyId);
+	}
+
+	private static String[] _getWebIdsBySQL() throws SQLException {
+		List<String> webIds = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select webId from Company");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				String webId = resultSet.getString("webId");
+
+				webIds.add(webId);
+			}
+		}
+
+		return webIds.toArray(new String[0]);
+	}
+
+	private static final String _COMPANY_DEFAULT_WEB_ID = PropsUtil.get(
+		PropsKeys.COMPANY_DEFAULT_WEB_ID);
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalInstancePool.class);
 
 	private static final Map<Long, String> _portalInstances =
 		new ConcurrentHashMap<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -14,8 +14,8 @@
 		<suppress checks="ChainingCheck" files="portal-impl/src/com/liferay/portal/tools/ConfigurationEnvBuilder\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
-		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector\.java" />
+		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess\.java" />
 		<suppress checks="ConcatCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/StringBundlerTest\.java" />
 		<suppress checks="ConstantNameCheck" files="portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor\.java" />


### PR DESCRIPTION
- LPS-206629 Unifying getCompanyXXX methods in PortalInstancePool class to avoid code duplications
- LPS-206629 PortalInstancePool is initialized atomically with the set method, until it is not called, all the methods check against the database
- LPS-206629 Replacing usages of deprecated APIs
- LPS-206629 Update SF rule
- LPS-206629 Baseline
- LPS-206629 Custom add company methods do not take into account PortalInstancePool, so we need to make sure in the tests it is always obtained from the database
