### PR TITLE
LPD-51006 Use CompanyInheritableThreadLocalCallable when creating threads that access to the database

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CreatingThreadsForDBAccessCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CreatingThreadsForDBAccessCheck.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.checkstyle.check;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+
+/**
+ * @author Alan Huang
+ */
+public class CreatingThreadsForDBAccessCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.LITERAL_NEW, TokenTypes.METHOD_CALL};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		if (detailAST.getType() == TokenTypes.LITERAL_NEW) {
+			DetailAST firstChildDetailAST = detailAST.getFirstChild();
+
+			if ((firstChildDetailAST == null) ||
+				(firstChildDetailAST.getType() != TokenTypes.IDENT)) {
+
+				return;
+			}
+
+			String className = firstChildDetailAST.getText();
+
+			if (!className.equals("FutureTask") &&
+				!className.equals("Thread")) {
+
+				return;
+			}
+
+			_checkDBAccess(detailAST);
+
+			return;
+		}
+
+		DetailAST dotDetailAST = detailAST.findFirstToken(TokenTypes.DOT);
+
+		if (dotDetailAST == null) {
+			return;
+		}
+
+		List<String> names = getNames(dotDetailAST, false);
+
+		if (names.size() != 2) {
+			return;
+		}
+
+		String methodCallClassName = names.get(0);
+		String methodCallMethodName = names.get(1);
+
+		if (methodCallClassName.equals("DependencyManagerSyncUtil") &&
+			methodCallMethodName.equals("registerSyncCallable")) {
+
+			_checkDBAccess(detailAST);
+
+			return;
+		}
+
+		if (Character.isUpperCase(methodCallClassName.charAt(0)) ||
+			!methodCallMethodName.equals("submit")) {
+
+			return;
+		}
+
+		String variableTypeName = getVariableTypeName(
+			detailAST, methodCallClassName, false);
+
+		if ((variableTypeName == null) ||
+			!variableTypeName.endsWith("ExecutorService")) {
+
+			return;
+		}
+
+		_checkDBAccess(detailAST);
+	}
+
+	private void _checkDBAccess(DetailAST detailAST) {
+		DetailAST elistDetailAST = detailAST.findFirstToken(TokenTypes.ELIST);
+
+		if (elistDetailAST == null) {
+			return;
+		}
+
+		DetailAST firstChildDetailAST = elistDetailAST.getFirstChild();
+
+		if ((firstChildDetailAST == null) ||
+			(firstChildDetailAST.getType() != TokenTypes.LAMBDA)) {
+
+			return;
+		}
+
+		List<DetailAST> methodCallDetailASTList = getAllChildTokens(
+			firstChildDetailAST, true, TokenTypes.METHOD_CALL);
+
+		for (DetailAST methodCallDetailAST : methodCallDetailASTList) {
+			DetailAST dotDetailAST = methodCallDetailAST.findFirstToken(
+				TokenTypes.DOT);
+
+			if (dotDetailAST == null) {
+				continue;
+			}
+
+			List<String> names = getNames(dotDetailAST, false);
+
+			if (names.size() != 2) {
+				continue;
+			}
+
+			String methodCallClassName = names.get(0);
+
+			if (!methodCallClassName.equals("CompanyThreadLocal") &&
+				!methodCallClassName.endsWith("LocalService") &&
+				!methodCallClassName.endsWith("LocalServiceUtil")) {
+
+				continue;
+			}
+
+			log(
+				methodCallDetailAST,
+				_MSG_USE_COMPANY_INHERITABLE_THREAD_LOCAL_CALLABLE);
+		}
+	}
+
+	private static final String
+		_MSG_USE_COMPANY_INHERITABLE_THREAD_LOCAL_CALLABLE =
+			"company.inheritable.thread.local.callable.use";
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CreatingThreadsForDBAccessCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/CreatingThreadsForDBAccessCheck.java
@@ -126,9 +126,7 @@ public class CreatingThreadsForDBAccessCheck extends BaseCheck {
 				continue;
 			}
 
-			log(
-				methodCallDetailAST,
-				_MSG_USE_COMPANY_INHERITABLE_THREAD_LOCAL_CALLABLE);
+			log(detailAST, _MSG_USE_COMPANY_INHERITABLE_THREAD_LOCAL_CALLABLE);
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -355,6 +355,11 @@
 			<property name="description" value="Finds contractions in Strings (such as `can't` or `you're`)." />
 			<message key="contraction.avoid" value="Avoid using contraction &quot;{0}&quot;" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.CreatingThreadsForDBAccessCheck">
+			<property name="category" value="Bug Prevention" />
+			<property name="description" value="Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access." />
+			<message key="company.inheritable.thread.local.callable.use" value="Use &quot;CompanyInheritableThreadLocalCallable&quot; to create threads for DB access" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.CreationMenuBuilderCheck">
 			<property name="category" value="Miscellaneous" />
 			<property name="checkInline" value="true" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -358,6 +358,7 @@
 		<module name="com.liferay.source.formatter.checkstyle.check.CreatingThreadsForDBAccessCheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access." />
+			<property name="enabled" value="false" />
 			<message key="company.inheritable.thread.local.callable.use" value="Use &quot;CompanyInheritableThreadLocalCallable&quot; to create threads for DB access" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.CreationMenuBuilderCheck">

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -67,6 +67,7 @@ ConstructorGlobalVariableDeclarationCheck | [Performance](performance_checks.mar
 ConsumerTypeAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Performs several checks on classes with @ConsumerType annotation. |
 ContractionsCheck | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds contractions in Strings (such as `can't` or `you're`). |
 [CopyrightCheck](check/copyright_check.markdown#copyrightcheck) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Validates `copyright` header. |
+[CreatingThreadsForDBAccessCheck](check/creating_threads_for_db_access_check.markdown#creatingthreadsfordbaccesscheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access. |
 [CreationMenuBuilderCheck](check/builder_check.markdown#buildercheck) | [Miscellaneous](miscellaneous_checks.markdown#miscellaneous-checks) | .java | Checks that `CreationMenuBuilder` is used when possible. |
 DTOEnumCreationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Checks the creation of DTO enum. |
 DatabaseMetaDataCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Checks usages of `java.sql.DatabaseMetaData`. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -35,6 +35,7 @@ CompatClassImportsCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks 
 ComponentAnnotationCheck | .java | Performs several checks on classes with @Component annotation. |
 [ComponentExposureCheck](check/component_exposure_check.markdown#componentexposurecheck) | .java | Avoid exposing static component. |
 ConsumerTypeAnnotationCheck | .java | Performs several checks on classes with @ConsumerType annotation. |
+[CreatingThreadsForDBAccessCheck](check/creating_threads_for_db_access_check.markdown#creatingthreadsfordbaccesscheck) | .java | Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access. |
 DTOEnumCreationCheck | .java | Checks the creation of DTO enum. |
 DatabaseMetaDataCheck | .java | Checks usages of `java.sql.DatabaseMetaData`. |
 DeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods. |

--- a/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown
@@ -1,0 +1,71 @@
+## CreatingThreadsForDBAccessCheck
+
+Use `CompanyInheritableThreadLocalCallable` to create threads for DB access
+when thread logic contains the usage of `CompanyThreadLocal`, `*LocalService`
+or `*LocalServiceUtil`.
+
+### Examples
+
+Incorrect:
+
+```java
+public void run() throws Exception {
+
+...
+
+    long companyId = CompanyThreadLocal.getNonsystemCompanyId();
+    String finalPortletName = portletName;
+    String finalPortletId = portletId;
+
+    FutureTask<com.liferay.portal.kernel.model.Portlet> futureTask =
+        new FutureTask<>(
+            () -> {
+                CompanyThreadLocal.setCompanyId(companyId);
+
+                com.liferay.portal.kernel.model.Portlet addedPortletModel =
+                    _addingPortlet(
+                        serviceReference, portlet, finalPortletName,
+                        finalPortletId);
+
+                if (addedPortletModel == null) {
+                    _bundleContext.ungetService(serviceReference);
+                }
+
+                return addedPortletModel;
+            });
+
+...
+
+}
+```
+
+Correct:
+
+```java
+public void run() throws Exception {
+
+...
+
+    String finalPortletName = portletName;
+    String finalPortletId = portletId;
+
+    FutureTask<com.liferay.portal.kernel.model.Portlet> futureTask =
+        new FutureTask<>(
+            new CompanyInheritableThreadLocalCallable<>(
+                () -> {
+                    com.liferay.portal.kernel.model.Portlet
+                        addedPortletModel = _addingPortlet(
+                            serviceReference, portlet, finalPortletName,
+                            finalPortletId);
+
+                    if (addedPortletModel == null) {
+                        _bundleContext.ungetService(serviceReference);
+                    }
+
+                    return addedPortletModel;
+                }));
+
+...
+
+}
+```

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -31,6 +31,7 @@ ConstructorGlobalVariableDeclarationCheck | [Performance](performance_checks.mar
 ConsumerTypeAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Performs several checks on classes with @ConsumerType annotation. |
 ContractionsCheck | [Styling](styling_checks.markdown#styling-checks) | Finds contractions in Strings (such as `can't` or `you're`). |
 [CopyrightCheck](check/copyright_check.markdown#copyrightcheck) | [Styling](styling_checks.markdown#styling-checks) | Validates `copyright` header. |
+[CreatingThreadsForDBAccessCheck](check/creating_threads_for_db_access_check.markdown#creatingthreadsfordbaccesscheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access. |
 [CreationMenuBuilderCheck](check/builder_check.markdown#buildercheck) | [Miscellaneous](miscellaneous_checks.markdown#miscellaneous-checks) | Checks that `CreationMenuBuilder` is used when possible. |
 DTOEnumCreationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks the creation of DTO enum. |
 DatabaseMetaDataCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks usages of `java.sql.DatabaseMetaData`. |

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -220,6 +220,8 @@
 
     checkstyle.ConstructorGlobalVariableDeclarationCheck.enabled=true
 
+    checkstyle.CreatingThreadsForDBAccessCheck.enabled=true
+
     checkstyle.CreationMenuBuilderCheck.enforceBuilderNames=\
         CreationMenuBuilder
 


### PR DESCRIPTION
@achaparro Please see SF result:
```
format-source-files:
     [java] Loading file:/opt/dev/projects/github/liferay-portal/portal-impl/classes/system.properties
     [java] java.lang.Exception: Found 11 formatting issues:
     [java] 1: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceThreadTest.java 53 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 2: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java 1723 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 3: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java 1741 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 4: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfigurationFactory.java 47 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 5: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java 77 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 6: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java 71 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 7: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java 93 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 8: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java 335 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 9: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/impl/test/ViewCountEntryLocalServiceTest.java 98 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 10: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./modules/dxp/apps/osb/osb-faro/osb-faro-contacts-demo/src/main/java/com/liferay/osb/faro/contacts/demo/internal/ContactsDemo.java 44 (Checkstyle:CreatingThreadsForDBAccessCheck)
     [java] 11: Use "CompanyInheritableThreadLocalCallable" to create threads for DB access, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/creating_threads_for_db_access_check.markdown: ./portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java 1074 (Checkstyle:CreatingThreadsForDBAccessCheck)

```